### PR TITLE
Fix AmbassadorDashboard JSX return

### DIFF
--- a/src/pages/ambassador/AmbassadorDashboard.tsx
+++ b/src/pages/ambassador/AmbassadorDashboard.tsx
@@ -73,8 +73,21 @@ const AmbassadorHome: React.FC = () => {
 
   const getStatusLabel = (status: Lead['status']) => {
     switch (status) {
-      case 'new': return 'Nouveau';
-      case 'contacted': return 'Contacté';
+      case 'new':
+        return 'Nouveau';
+      case 'contacted':
+        return 'Contacté';
+      case 'qualified':
+        return 'Qualifié';
+      case 'converted':
+        return 'Converti';
+      default:
+        return status;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <Card className="p-6">
           <div className="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary
- finish `getStatusLabel` cases
- wrap AmbassadorHome JSX in a return block

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: src/pages/seller/ContractsPage.tsx errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849eb752c54833085cb39e407b089fa