### PR TITLE
Remove unused hook from Ambassador dashboard

### DIFF
--- a/src/pages/ambassador/AmbassadorDashboard.tsx
+++ b/src/pages/ambassador/AmbassadorDashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, Navigate, Link, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate, Link } from 'react-router-dom';
 import { DashboardLayout } from '../../components/dashboard/DashboardLayout';
 import { Card } from '../../components/ui/Card';
 import { Badge } from '../../components/ui/Badge';
@@ -352,7 +352,6 @@ const AmbassadorHome: React.FC = () => {
 };
 
 export const AmbassadorDashboard: React.FC = () => {
-  const location = useLocation();
 
   return (
     <Routes>


### PR DESCRIPTION
## Summary
- clean up AmbassadorDashboard by removing an unused `useLocation` import and variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849eec352488330a7b9d0fedfb4117a