### PR TITLE
Introduce dataService and use mocks via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Lint the project:
 npm run lint
 ```
 
+### Mock data service
+
+The project uses a small data service located in `src/services/dataService.ts` to
+provide application data. When the `VITE_USE_MOCKS` environment variable is set
+to `true` (the default), the service returns arrays from the mock files under
+`src/data` and `src/mocks`. Set `VITE_USE_MOCKS=false` to disable these mocks –
+the functions will then throw errors until real API calls are implemented.
+This design makes it easy to replace the mock logic with actual HTTP requests in
+the future.
+
 
 ## License
 

--- a/src/components/ambassador/ReferralManagement.tsx
+++ b/src/components/ambassador/ReferralManagement.tsx
@@ -7,7 +7,7 @@ import {
   XCircle, Euro, MessageSquare, Phone, Mail, Calendar,
   TrendingUp, AlertCircle, ChevronRight, Filter
 } from 'lucide-react';
-import { mockReferrals } from '../../data/mockReferrals';
+import { getReferrals } from '../../services/dataService';
 import { AmbassadorReferral } from '../../types';
 import { cn } from '../../utils/cn';
 
@@ -15,8 +15,9 @@ export const ReferralManagement: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'sent' | 'received'>('sent');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
 
-  const sentReferrals = mockReferrals.filter(r => r.referringAmbassadorId === '3');
-  const receivedReferrals = mockReferrals.filter(r => r.receivingAmbassadorId === '3');
+  const referrals = getReferrals();
+  const sentReferrals = referrals.filter(r => r.referringAmbassadorId === '3');
+  const receivedReferrals = referrals.filter(r => r.receivingAmbassadorId === '3');
 
   const getStatusBadge = (status: AmbassadorReferral['status']) => {
     const config = {

--- a/src/components/ambassador/TerritoryAlerts.tsx
+++ b/src/components/ambassador/TerritoryAlerts.tsx
@@ -8,7 +8,7 @@ import {
   ChevronRight, Eye, Heart, Share2, UserPlus,
   TrendingUp, Clock, CheckCircle, AlertCircle
 } from 'lucide-react';
-import { mockTerritoryProperties } from '../../data/mockReferrals';
+import { getTerritoryProperties } from '../../services/dataService';
 import { cn } from '../../utils/cn';
 
 export const TerritoryAlerts: React.FC = () => {
@@ -16,7 +16,7 @@ export const TerritoryAlerts: React.FC = () => {
   const [showReferralModal, setShowReferralModal] = useState(false);
   const [filter, setFilter] = useState<'all' | 'referral_enabled' | 'my_zone'>('all');
 
-  const properties = mockTerritoryProperties.filter(p => {
+  const properties = getTerritoryProperties().filter(p => {
     if (filter === 'referral_enabled') return p.allowsReferrals;
     if (filter === 'my_zone') return true; // Filter by ambassador's territory
     return true;

--- a/src/components/services/PropertyServiceProposals.tsx
+++ b/src/components/services/PropertyServiceProposals.tsx
@@ -9,7 +9,7 @@ import {
   ChevronDown, ChevronUp, Plus, Check, X, Clock, MessageSquare,
   Filter, Search
 } from 'lucide-react';
-import { mockServiceProviders, mockServiceProposals } from '../../data/mockServiceProviders';
+import { getServiceProviders, getServiceProposals } from '../../services/dataService';
 import { cn } from '../../utils/cn';
 
 interface PropertyServiceProposalsProps {
@@ -21,11 +21,12 @@ export const PropertyServiceProposals: React.FC<PropertyServiceProposalsProps> =
   property,
   userRole
 }) => {
+  const serviceProviders = getServiceProviders();
+  const [activeProposals] = useState<ServiceProposal[]>(
+    getServiceProposals().filter(p => p.propertyId === property.id)
+  );
   const [expandedCategories, setExpandedCategories] = useState<string[]>([]);
   const [selectedProviders, setSelectedProviders] = useState<{[key: string]: ServiceProvider}>({});
-  const [activeProposals] = useState<ServiceProposal[]>(
-    mockServiceProposals.filter(p => p.propertyId === property.id)
-  );
   const [filterType, setFilterType] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -97,7 +98,7 @@ export const PropertyServiceProposals: React.FC<PropertyServiceProposalsProps> =
   };
 
   const getProvidersForCategory = (category: string) => {
-    return mockServiceProviders
+    return serviceProviders
       .filter(p => p.type === category)
       .filter(p => 
         searchQuery === '' || 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { User, UserRole } from '../types';
-import { mockUsers } from '../data/mockData';
+import { getUsers } from '../services/dataService';
 
 export interface RegisterData {
   email: string;
@@ -57,7 +57,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const login = async (email: string, password: string) => {
     // Mock authentication
-    const user = mockUsers.find(u => u.email === email);
+    const user = getUsers().find(u => u.email === email);
     
     if (user && password === 'test123') {
       setUser(user);
@@ -83,7 +83,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       createdAt: new Date()
     };
 
-    mockUsers.push(newUser);
+    getUsers().push(newUser);
     setUser(newUser);
     setActiveRole(data.roles[0]);
     localStorage.setItem('user', JSON.stringify(newUser));

--- a/src/pages/PropertyDetailPage.tsx
+++ b/src/pages/PropertyDetailPage.tsx
@@ -9,7 +9,7 @@ import { Navbar } from '../components/layout/Navbar';
 import { Footer } from '../components/layout/Footer';
 import { Button } from '../components/ui/Button';
 import { Card } from '../components/ui/Card';
-import { mockProperties } from '../data/mockData';
+import { getProperties } from '../services/dataService';
 import { cn } from '../utils/cn';
 
 export const PropertyDetailPage: React.FC = () => {
@@ -20,8 +20,10 @@ export const PropertyDetailPage: React.FC = () => {
   const [selectedVisitSlot, setSelectedVisitSlot] = useState<string | null>(null);
   const [showContactForm, setShowContactForm] = useState(false);
 
+  const properties = getProperties();
+
   // Find property - in real app, fetch from API
-  const property = mockProperties.find(p => p.id === id);
+  const property = properties.find(p => p.id === id);
 
   if (!property) {
     return (
@@ -46,7 +48,7 @@ export const PropertyDetailPage: React.FC = () => {
     setCurrentImageIndex((prev) => (prev - 1 + property.photos.length) % property.photos.length);
   };
 
-  const similarProperties = mockProperties.filter(p => 
+  const similarProperties = properties.filter(p =>
     p.id !== property.id && 
     p.type === property.type && 
     Math.abs(p.price - property.price) < 100000

--- a/src/pages/SearchResultsPage.tsx
+++ b/src/pages/SearchResultsPage.tsx
@@ -9,7 +9,8 @@ import { Footer } from '../components/layout/Footer';
 import { Button } from '../components/ui/Button';
 import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
-import { mockProperties } from '../data/mockData';
+import { getProperties } from '../services/dataService';
+import { Property } from '../types';
 import { cn } from '../utils/cn';
 
 type ViewMode = 'grid' | 'list' | 'map';
@@ -30,13 +31,15 @@ export const SearchResultsPage: React.FC = () => {
   const [selectedFeatures, setSelectedFeatures] = useState<string[]>([]);
   const [rooms, setRooms] = useState<number | null>(null);
 
+  const properties = getProperties();
+
   // Get search parameters
   const location = searchParams.get('location') || '';
   const type = searchParams.get('type') || '';
   const budget = searchParams.get('budget') || '';
 
   // Filter properties based on search criteria
-  const filteredProperties = mockProperties.filter(property => {
+  const filteredProperties = properties.filter(property => {
     let matches = true;
     
     if (location && !property.location.city.toLowerCase().includes(location.toLowerCase())) {
@@ -102,7 +105,7 @@ export const SearchResultsPage: React.FC = () => {
     });
   };
 
-  const PropertyCard = ({ property }: { property: typeof mockProperties[0] }) => {
+  const PropertyCard = ({ property }: { property: Property }) => {
     const isFavorite = favorites.has(property.id);
     const daysAgo = Math.floor((new Date().getTime() - property.createdAt.getTime()) / (1000 * 60 * 60 * 24));
     

--- a/src/pages/SellerPage.tsx
+++ b/src/pages/SellerPage.tsx
@@ -10,7 +10,7 @@ import {
   FileText, Upload, BarChart3, Zap, Shield, ChevronRight,
   Building, Download, Info, Rocket, FileCheck, AlertTriangle
 } from 'lucide-react';
-import { mockProperties } from '../data/mockData';
+import { getProperties } from '../services/dataService';
 import { formatPrice, formatPercentage } from '../utils/calculations';
 import { cn } from '../utils/cn';
 
@@ -38,8 +38,10 @@ export const SellerPage: React.FC = () => {
   const [showBoostModal, setShowBoostModal] = useState(false);
   const [activeTab, setActiveTab] = useState<'overview' | 'analytics' | 'documents'>('overview');
 
+  const properties = getProperties();
+
   // Mock data for demonstration
-  const userProperties = mockProperties.slice(0, 3);
+  const userProperties = properties.slice(0, 3);
   
   const quickStats: QuickStats = {
     totalViews: 1846,

--- a/src/pages/ambassador/AmbassadorDashboard.tsx
+++ b/src/pages/ambassador/AmbassadorDashboard.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react';
 import { formatPrice } from '../../utils/calculations';
 import { cn } from '../../utils/cn';
-import { mockStats, mockLeads, mockDashboardCommissions } from "../../mocks";
+import { getStats, getLeads, getDashboardCommissions } from "../../services/dataService";
 
 // Import des pages existantes
 import { AmbassadorPropertiesPage } from './PropertiesPage';
@@ -61,6 +61,10 @@ interface Commission {
 
 
 const AmbassadorHome: React.FC = () => {
+  const stats = getStats();
+  const leads = getLeads();
+  const dashboardCommissions = getDashboardCommissions();
+
   const getStatusColor = (status: Lead['status']) => {
     switch (status) {
       case 'new': return 'info';
@@ -96,12 +100,12 @@ const AmbassadorHome: React.FC = () => {
             </div>
             <Badge variant="success" size="sm">
               <ArrowUp className="w-3 h-3 mr-1" />
-              +{mockStats.monthlyGrowth}%
+              +{stats.monthlyGrowth}%
             </Badge>
           </div>
           <p className="text-sm text-gray-600 mb-1">Gains totaux</p>
-          <p className="text-2xl font-bold text-gray-900">{formatPrice(mockStats.totalEarnings)}</p>
-          <p className="text-xs text-gray-500 mt-1">Commission moyenne: {formatPrice(mockStats.averageCommission)}</p>
+          <p className="text-2xl font-bold text-gray-900">{formatPrice(stats.totalEarnings)}</p>
+          <p className="text-xs text-gray-500 mt-1">Commission moyenne: {formatPrice(stats.averageCommission)}</p>
         </Card>
 
         <Card className="p-6">
@@ -109,7 +113,7 @@ const AmbassadorHome: React.FC = () => {
             <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
               <Trophy className="w-6 h-6 text-blue-600" />
             </div>
-            <span className="text-2xl font-bold text-gray-900">{mockStats.totalSales}</span>
+            <span className="text-2xl font-bold text-gray-900">{stats.totalSales}</span>
           </div>
           <p className="text-sm text-gray-600 mb-1">Ventes réalisées</p>
           <div className="flex items-center gap-2 mt-2">
@@ -125,7 +129,7 @@ const AmbassadorHome: React.FC = () => {
             <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center">
               <Home className="w-6 h-6 text-purple-600" />
             </div>
-            <span className="text-2xl font-bold text-gray-900">{mockStats.activeProperties}</span>
+            <span className="text-2xl font-bold text-gray-900">{stats.activeProperties}</span>
           </div>
           <p className="text-sm text-gray-600 mb-1">Biens actifs</p>
           <p className="text-xs text-gray-500 mt-1">3 nouvelles opportunités cette semaine</p>
@@ -136,7 +140,7 @@ const AmbassadorHome: React.FC = () => {
             <div className="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center">
               <Target className="w-6 h-6 text-orange-600" />
             </div>
-            <span className="text-2xl font-bold text-gray-900">{mockStats.conversionRate}%</span>
+            <span className="text-2xl font-bold text-gray-900">{stats.conversionRate}%</span>
           </div>
           <p className="text-sm text-gray-600 mb-1">Taux de conversion</p>
           <p className="text-xs text-gray-500 mt-1">Moyenne réseau: 18%</p>
@@ -207,7 +211,7 @@ const AmbassadorHome: React.FC = () => {
               </div>
 
               <div className="space-y-3">
-                {mockLeads.map((lead) => (
+                {leads.map((lead) => (
                   <div key={lead.id} className="p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
                     <div className="flex items-start justify-between mb-2">
                       <div>
@@ -258,7 +262,7 @@ const AmbassadorHome: React.FC = () => {
               <h2 className="text-lg font-semibold text-gray-900 mb-4">Commissions récentes</h2>
               
               <div className="space-y-3">
-                {mockDashboardCommissions.slice(0, 3).map((commission) => (
+                {dashboardCommissions.slice(0, 3).map((commission) => (
                   <div key={commission.id} className="pb-3 border-b last:border-0">
                     <div className="flex items-start justify-between mb-1">
                       <p className="text-sm font-medium text-gray-900">{commission.propertyTitle}</p>

--- a/src/pages/ambassador/CommissionsPage.tsx
+++ b/src/pages/ambassador/CommissionsPage.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../../utils/cn';
 import { formatPrice } from '../../utils/calculations';
-import { mockCommissions } from "../../mocks";
+import { getCommissions } from "../../services/dataService";
 
 // Types pour les commissions
 interface Commission {
@@ -264,8 +264,10 @@ export const CommissionsPage: React.FC = () => {
   const [filterType, setFilterType] = useState<string>('all');
   const [filterStatus, setFilterStatus] = useState<string>('all');
 
+  const commissions = getCommissions();
+
   // Filtrer les commissions
-  const filteredCommissions = mockCommissions.filter(commission => {
+  const filteredCommissions = commissions.filter(commission => {
     if (filterType !== 'all' && commission.type !== filterType) return false;
     if (filterStatus !== 'all' && commission.status !== filterStatus) return false;
     return true;

--- a/src/pages/ambassador/LeadsPage.tsx
+++ b/src/pages/ambassador/LeadsPage.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../../utils/cn';
 
-import { mockEnrichedLeads } from "../../mocks";
+import { getEnrichedLeads } from "../../services/dataService";
 // Types étendus pour les leads
 interface ExtendedLead {
   id: string;
@@ -106,12 +106,14 @@ export const LeadsPage: React.FC = () => {
   const [selectedView, setSelectedView] = useState<'priority' | 'all' | 'scheduled'>('priority');
   const [selectedLead, setSelectedLead] = useState<ExtendedLead | null>(null);
 
+  const leads = getEnrichedLeads();
+
   // Calculs des métriques
   const metrics = {
-    totalLeads: mockEnrichedLeads.length,
-    newLeads: mockEnrichedLeads.filter(l => l.status === 'new').length,
-    urgentLeads: mockEnrichedLeads.filter(l => l.urgency === 'immediate' || l.urgency === 'high').length,
-    scheduledVisits: mockEnrichedLeads.filter(l => l.status === 'visit_scheduled').length,
+    totalLeads: leads.length,
+    newLeads: leads.filter(l => l.status === 'new').length,
+    urgentLeads: leads.filter(l => l.urgency === 'immediate' || l.urgency === 'high').length,
+    scheduledVisits: leads.filter(l => l.status === 'visit_scheduled').length,
     conversionRate: 35,
     avgResponseTime: 4.5
   };
@@ -120,16 +122,16 @@ export const LeadsPage: React.FC = () => {
   const getFilteredLeads = () => {
     switch (selectedView) {
       case 'priority':
-        return mockEnrichedLeads
+        return leads
           .filter(l => l.status === 'new' || l.urgency === 'immediate' || l.urgency === 'high')
           .sort((a, b) => {
             const urgencyOrder = { immediate: 0, high: 1, medium: 2, low: 3 };
             return urgencyOrder[a.urgency] - urgencyOrder[b.urgency];
           });
       case 'scheduled':
-        return mockEnrichedLeads.filter(l => l.nextAction);
+        return leads.filter(l => l.nextAction);
       default:
-        return mockEnrichedLeads;
+        return leads;
     }
   };
 

--- a/src/pages/ambassador/PhotosPage.tsx
+++ b/src/pages/ambassador/PhotosPage.tsx
@@ -9,7 +9,7 @@ import {
   Info, ChevronLeft
 } from 'lucide-react';
 import { cn } from '../../utils/cn';
-import { mockPropertyPhotos } from "../../mocks";
+import { getPropertyPhotos } from "../../services/dataService";
 
 interface PropertyPhotos {
   propertyId: string;
@@ -28,6 +28,8 @@ interface PropertyPhotos {
 export const AmbassadorPhotosPage: React.FC = () => {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [selectedPhotos, setSelectedPhotos] = useState<string[]>([]);
+
+  const propertyPhotos = getPropertyPhotos();
 
   const handlePhotoSelect = (photoId: string) => {
     if (selectedPhotos.includes(photoId)) {
@@ -52,7 +54,7 @@ export const AmbassadorPhotosPage: React.FC = () => {
               Retour aux biens
             </Button>
             <h1 className="text-2xl font-bold text-gray-900">Photos du bien</h1>
-            <p className="text-gray-600 mt-1">{mockPropertyPhotos.propertyTitle}</p>
+            <p className="text-gray-600 mt-1">{propertyPhotos.propertyTitle}</p>
           </div>
           <Button variant="primary">
             <Upload className="w-4 h-4 mr-2" />
@@ -65,11 +67,11 @@ export const AmbassadorPhotosPage: React.FC = () => {
           <div className="flex items-center gap-4">
             <Home className="w-5 h-5 text-gray-500" />
             <div>
-              <p className="font-medium text-gray-900">{mockPropertyPhotos.propertyTitle}</p>
-              <p className="text-sm text-gray-600">{mockPropertyPhotos.propertyAddress}</p>
+              <p className="font-medium text-gray-900">{propertyPhotos.propertyTitle}</p>
+              <p className="text-sm text-gray-600">{propertyPhotos.propertyAddress}</p>
             </div>
             <Badge variant="info" className="ml-auto">
-              {mockPropertyPhotos.photos.length} photos
+              {propertyPhotos.photos.length} photos
             </Badge>
           </div>
         </Card>
@@ -135,7 +137,7 @@ export const AmbassadorPhotosPage: React.FC = () => {
         {/* Photos Grid/List */}
         {viewMode === 'grid' ? (
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-            {mockPropertyPhotos.photos.map((photo) => (
+            {propertyPhotos.photos.map((photo) => (
               <Card key={photo.id} className="overflow-hidden group cursor-pointer hover:shadow-lg transition-shadow">
                 <div className="relative aspect-square">
                   <img 
@@ -187,7 +189,7 @@ export const AmbassadorPhotosPage: React.FC = () => {
           </div>
         ) : (
           <div className="space-y-2">
-            {mockPropertyPhotos.photos.map((photo) => (
+            {propertyPhotos.photos.map((photo) => (
               <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow">
                 <div className="flex items-center gap-4">
                   <input
@@ -238,7 +240,7 @@ export const AmbassadorPhotosPage: React.FC = () => {
         )}
 
         {/* Empty State */}
-        {mockPropertyPhotos.photos.length === 0 && (
+        {propertyPhotos.photos.length === 0 && (
           <Card className="p-12 text-center">
             <Camera className="w-16 h-16 text-gray-300 mx-auto mb-4" />
             <h3 className="text-lg font-semibold text-gray-900 mb-2">

--- a/src/pages/ambassador/PropertiesPage.tsx
+++ b/src/pages/ambassador/PropertiesPage.tsx
@@ -11,7 +11,7 @@ import {
 import { formatPrice } from '../../utils/calculations';
 import { cn } from '../../utils/cn';
 
-import { mockManagedProperties } from "../../mocks";
+import { getManagedProperties } from "../../services/dataService";
 interface ManagedProperty {
   id: string;
   title: string;
@@ -39,6 +39,8 @@ interface ManagedProperty {
 export const AmbassadorPropertiesPage: React.FC = () => {
   const [showForm, setShowForm] = useState(false);
   const [selectedProperty, setSelectedProperty] = useState<ManagedProperty | null>(null);
+
+  const managedProperties = getManagedProperties();
 
   const handleSaveProperty = (data: any) => {
     console.log('Saving property:', data);
@@ -97,7 +99,7 @@ export const AmbassadorPropertiesPage: React.FC = () => {
 
         {/* Properties List */}
         <div className="space-y-4">
-          {mockManagedProperties.map((property) => (
+          {managedProperties.map((property) => (
             <Card key={property.id} className="overflow-hidden">
               <div className="p-6">
                 <div className="flex items-start justify-between">
@@ -218,7 +220,7 @@ export const AmbassadorPropertiesPage: React.FC = () => {
         </div>
 
         {/* Empty State */}
-        {mockManagedProperties.length === 0 && (
+        {managedProperties.length === 0 && (
           <Card className="p-12 text-center">
             <Home className="w-16 h-16 text-gray-300 mx-auto mb-4" />
             <h3 className="text-lg font-semibold text-gray-900 mb-2">

--- a/src/pages/ambassador/ProposePropertyPage.tsx
+++ b/src/pages/ambassador/ProposePropertyPage.tsx
@@ -12,7 +12,7 @@ import {
   Send, UserCheck, ShieldCheck, ArrowRight
 } from 'lucide-react';
 import { cn } from '../../utils/cn';
-import { mockProposals } from "../../mocks";
+import { getProposals } from "../../services/dataService";
 import { formatPrice } from '../../utils/calculations';
 
 // Types pour les propositions
@@ -179,15 +179,17 @@ export const ProposePropertyPage: React.FC = () => {
   const [selectedProposal, setSelectedProposal] = useState<PropertyProposal | null>(null);
   const [activeTab, setActiveTab] = useState<'all' | 'pending' | 'approved'>('all');
 
+  const proposals = getProposals();
+
   // Filtrer les propositions
   const getFilteredProposals = () => {
     switch (activeTab) {
       case 'pending':
-        return mockProposals.filter(p => p.status === 'pending_owner' || p.status === 'pending_staff');
+        return proposals.filter(p => p.status === 'pending_owner' || p.status === 'pending_staff');
       case 'approved':
-        return mockProposals.filter(p => p.status === 'approved');
+        return proposals.filter(p => p.status === 'approved');
       default:
-        return mockProposals;
+        return proposals;
     }
   };
 
@@ -195,10 +197,10 @@ export const ProposePropertyPage: React.FC = () => {
 
   // Stats
   const stats = {
-    total: mockProposals.length,
-    pending: mockProposals.filter(p => p.status === 'pending_owner' || p.status === 'pending_staff').length,
-    approved: mockProposals.filter(p => p.status === 'approved').length,
-    potentialCommission: mockProposals.reduce((sum, p) => sum + p.estimatedCommission, 0)
+    total: proposals.length,
+    pending: proposals.filter(p => p.status === 'pending_owner' || p.status === 'pending_staff').length,
+    approved: proposals.filter(p => p.status === 'approved').length,
+    potentialCommission: proposals.reduce((sum, p) => sum + p.estimatedCommission, 0)
   };
 
   if (showForm) {

--- a/src/pages/ambassador/TerritoryPage.tsx
+++ b/src/pages/ambassador/TerritoryPage.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../../utils/cn';
 
-import { mockZones } from "../../mocks";
+import { getZones } from "../../services/dataService";
 // Types pour le territoire
 interface Zone {
   id: string;
@@ -219,6 +219,8 @@ const ZoneCard: React.FC<{ zone: Zone; onAction: () => void }> = ({ zone, onActi
 export const TerritoryPage: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState<'overview' | 'zones' | 'performance'>('overview');
 
+  const zones = getZones();
+
   return (
     <DashboardLayout role="ambassador">
       <div className="space-y-6">
@@ -395,7 +397,7 @@ export const TerritoryPage: React.FC = () => {
 
         {selectedTab === 'zones' && (
           <div className="grid lg:grid-cols-2 gap-6">
-            {mockZones.map(zone => (
+            {zones.map(zone => (
               <ZoneCard 
                 key={zone.id} 
                 zone={zone}
@@ -411,7 +413,7 @@ export const TerritoryPage: React.FC = () => {
             <Card className="p-6">
               <h3 className="font-semibold text-gray-900 mb-4">Performance par zone</h3>
               <div className="space-y-4">
-                {mockZones
+                {zones
                   .filter(z => z.status === 'active')
                   .map(zone => (
                     <div key={zone.id}>

--- a/src/pages/ambassador/VisitsManagementPage.tsx
+++ b/src/pages/ambassador/VisitsManagementPage.tsx
@@ -13,7 +13,7 @@ import {
 import { cn } from '../../utils/cn';
 import { formatPrice } from '../../utils/calculations';
 
-import { mockVisits } from "../../mocks";
+import { getVisits } from "../../services/dataService";
 // Types pour les visites
 interface AmbassadorVisit {
   id: string;
@@ -183,22 +183,24 @@ export const AmbassadorVisitsManagementPage: React.FC = () => {
   const [selectedVisit, setSelectedVisit] = useState<AmbassadorVisit | null>(null);
   const [filterStatus, setFilterStatus] = useState<string>('all');
 
+  const visits = getVisits();
+
   // Filtrer les visites
-  const filteredVisits = filterStatus === 'all' 
-    ? mockVisits 
-    : mockVisits.filter(v => v.status === filterStatus);
+  const filteredVisits = filterStatus === 'all'
+    ? visits
+    : visits.filter(v => v.status === filterStatus);
 
   // Visites du jour
-  const todayVisits = mockVisits.filter(v => 
+  const todayVisits = visits.filter(v =>
     v.date.toDateString() === new Date().toDateString()
   ).sort((a, b) => a.time.localeCompare(b.time));
 
   // Stats
   const stats = {
-    scheduled: mockVisits.filter(v => v.status === 'scheduled' || v.status === 'confirmed').length,
-    completed: mockVisits.filter(v => v.status === 'completed').length,
-    cancelled: mockVisits.filter(v => v.status === 'cancelled').length,
-    totalCommission: mockVisits.filter(v => v.status === 'completed').reduce((sum, v) => sum + (v.commission || 0), 0),
+    scheduled: visits.filter(v => v.status === 'scheduled' || v.status === 'confirmed').length,
+    completed: visits.filter(v => v.status === 'completed').length,
+    cancelled: visits.filter(v => v.status === 'cancelled').length,
+    totalCommission: visits.filter(v => v.status === 'completed').reduce((sum, v) => sum + (v.commission || 0), 0),
     avgRating: 4.8,
     conversionRate: 65
   };

--- a/src/pages/buyer/BuyerFavorites.tsx
+++ b/src/pages/buyer/BuyerFavorites.tsx
@@ -8,13 +8,15 @@ import {
   Trash2, Bell, TrendingDown, Clock, Filter, SortDesc
 } from 'lucide-react';
 import { formatPrice } from '../../utils/calculations';
-import { mockProperties } from '../../data/mockData';
+import { getProperties } from '../../services/dataService';
 
 export const BuyerFavorites: React.FC = () => {
   const [sortBy, setSortBy] = useState<'recent' | 'price' | 'surface'>('recent');
+
+  const properties = getProperties();
   
   // Simuler des favoris avec des métadonnées supplémentaires
-  const favorites = mockProperties.slice(0, 5).map((property, index) => ({
+  const favorites = properties.slice(0, 5).map((property, index) => ({
     ...property,
     savedDate: new Date(Date.now() - index * 86400000).toLocaleDateString('fr-FR'),
     priceChange: index === 1 ? -15000 : index === 3 ? -8000 : 0,

--- a/src/pages/buyer/BuyerSearch.tsx
+++ b/src/pages/buyer/BuyerSearch.tsx
@@ -8,7 +8,7 @@ import {
   Heart, Calendar, ChevronDown, Map, List, Grid3x3
 } from 'lucide-react';
 import { formatPrice } from '../../utils/calculations';
-import { mockProperties } from '../../data/mockData';
+import { getProperties } from '../../services/dataService';
 
 export const BuyerSearch: React.FC = () => {
   const [viewMode, setViewMode] = useState<'grid' | 'list' | 'map'>('grid');
@@ -19,6 +19,8 @@ export const BuyerSearch: React.FC = () => {
     rooms: '',
     location: ''
   });
+
+  const properties = getProperties();
 
   return (
     <DashboardLayout role="buyer">
@@ -121,7 +123,7 @@ export const BuyerSearch: React.FC = () => {
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-lg font-semibold text-gray-900">
-              {mockProperties.length} biens trouvés
+              {properties.length} biens trouvés
             </h2>
             <p className="text-sm text-gray-600">
               Correspondant à vos critères de recherche
@@ -152,7 +154,7 @@ export const BuyerSearch: React.FC = () => {
         {/* Results Grid */}
         {viewMode === 'grid' && (
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {mockProperties.map((property) => (
+            {properties.map((property) => (
               <Card key={property.id} className="overflow-hidden hover:shadow-lg transition-shadow">
                 <div className="relative h-48">
                   <img 
@@ -212,7 +214,7 @@ export const BuyerSearch: React.FC = () => {
 
         {viewMode === 'list' && (
           <div className="space-y-4">
-            {mockProperties.map((property) => (
+            {properties.map((property) => (
               <Card key={property.id} className="p-6 hover:shadow-lg transition-shadow">
                 <div className="flex gap-6">
                   <img 

--- a/src/pages/seller/ContractsPage.tsx
+++ b/src/pages/seller/ContractsPage.tsx
@@ -12,8 +12,7 @@ import {
 } from 'lucide-react';
 import { formatPrice } from '../../utils/calculations';
 import { cn } from '../../utils/cn';
-import { mockProperties } from '../../data/mockData';
-import { mockContracts, mockTimelines } from "../../mocks";
+import { getProperties, getContracts, getTimelines } from "../../services/dataService";
 
 interface Contract {
   id: string;
@@ -64,8 +63,12 @@ export const ContractsPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [showSignatureModal, setShowSignatureModal] = useState(false);
 
+  const properties = getProperties();
+  const contracts = getContracts();
+  const timelines = getTimelines();
+
   // Filtrer les contrats
-  const filteredContracts = mockContracts.filter(contract => {
+  const filteredContracts = contracts.filter(contract => {
     const matchesProperty = selectedProperty === 'all' || contract.propertyId === selectedProperty;
     const matchesType = selectedType === 'all' || contract.type === selectedType;
     const matchesSearch = searchQuery === '' || 
@@ -77,8 +80,8 @@ export const ContractsPage: React.FC = () => {
 
   // Statistiques par bien
   const getPropertyContractStats = (propertyId: string) => {
-    const propertyContracts = mockContracts.filter(c => c.propertyId === propertyId);
-    const timeline = mockTimelines.find(t => t.propertyId === propertyId);
+    const propertyContracts = contracts.filter(c => c.propertyId === propertyId);
+    const timeline = timelines.find(t => t.propertyId === propertyId);
       case 'offer': return TrendingUp;
       case 'promise': return FileSignature;
       case 'sale': return Stamp;
@@ -193,7 +196,7 @@ export const ContractsPage: React.FC = () => {
                   <Home className="w-4 h-4 inline mr-2" />
                   Tous les biens
                 </button>
-                {mockProperties.map((property) => {
+                {properties.map((property) => {
                   const stats = getPropertyContractStats(property.id);
                   return (
                     <button
@@ -255,8 +258,8 @@ export const ContractsPage: React.FC = () => {
 
         {/* Chronologie par bien (si un bien est sélectionné) */}
         {selectedProperty !== 'all' && (() => {
-          const property = mockProperties.find(p => p.id === selectedProperty);
-          const timeline = mockTimelines.find(t => t.propertyId === selectedProperty);
+          const property = properties.find(p => p.id === selectedProperty);
+          const timeline = timelines.find(t => t.propertyId === selectedProperty);
           
           if (!timeline) return null;
 
@@ -342,7 +345,7 @@ export const ContractsPage: React.FC = () => {
           ) : (
             filteredContracts.map((contract) => {
               const Icon = getContractIcon(contract.type);
-              const property = mockProperties.find(p => p.id === contract.propertyId);
+              const property = properties.find(p => p.id === contract.propertyId);
               const allSigned = contract.parties.every(p => p.signed);
               const pendingSignatures = contract.parties.filter(p => !p.signed).length;
               
@@ -534,8 +537,8 @@ export const ContractsPage: React.FC = () => {
               Progression des ventes par bien
             </h2>
             <div className="grid gap-4">
-              {mockProperties.map((property) => {
-                const timeline = mockTimelines.find(t => t.propertyId === property.id);
+              {properties.map((property) => {
+                const timeline = timelines.find(t => t.propertyId === property.id);
                 const stats = getPropertyContractStats(property.id);
                 const currentStep = timeline?.steps.find(s => s.status === 'current');
                 const completedSteps = timeline?.steps.filter(s => s.status === 'completed').length || 0;

--- a/src/pages/seller/DocumentsPage.tsx
+++ b/src/pages/seller/DocumentsPage.tsx
@@ -11,7 +11,7 @@ import {
   ChevronRight, Paperclip, FileX, RefreshCw
 } from 'lucide-react';
 import { cn } from '../../utils/cn';
-import { mockProperties } from '../../data/mockData';
+import { getProperties } from '../../services/dataService';
 
 interface Document {
   id: string;
@@ -45,6 +45,8 @@ export const DocumentsPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [showRequirementsModal, setShowRequirementsModal] = useState(false);
+
+  const properties = getProperties();
 
   // Documents requis
   const documentRequirements: DocumentRequirement[] = [
@@ -258,7 +260,7 @@ export const DocumentsPage: React.FC = () => {
   // Calculer les statistiques par bien
   const getPropertyStats = (propertyId: string) => {
     const propertyDocs = documents.filter(d => d.propertyId === propertyId);
-    const property = mockProperties.find(p => p.id === propertyId);
+    const property = properties.find(p => p.id === propertyId);
     const requiredDocs = documentRequirements.filter(req => 
       req.category === 'property' && 
       req.required &&
@@ -282,8 +284,8 @@ export const DocumentsPage: React.FC = () => {
 
   // Statistiques globales
   const globalStats = {
-    totalProperties: mockProperties.length,
-    completeProperties: mockProperties.filter(p => getPropertyStats(p.id).completion === 100).length,
+    totalProperties: properties.length,
+    completeProperties: properties.filter(p => getPropertyStats(p.id).completion === 100).length,
     totalDocuments: documents.length,
     validDocuments: documents.filter(d => d.status === 'valid').length,
     pendingDocuments: documents.filter(d => d.status === 'pending').length,
@@ -400,7 +402,7 @@ export const DocumentsPage: React.FC = () => {
                   <Home className="w-4 h-4 inline mr-2" />
                   Tous les biens
                 </button>
-                {mockProperties.map((property) => {
+                {properties.map((property) => {
                   const stats = getPropertyStats(property.id);
                   return (
                     <button
@@ -466,7 +468,7 @@ export const DocumentsPage: React.FC = () => {
         {selectedProperty !== 'all' && (
           <Card className="p-6 bg-gradient-to-r from-primary-50 to-primary-100">
             {(() => {
-              const property = mockProperties.find(p => p.id === selectedProperty);
+              const property = properties.find(p => p.id === selectedProperty);
               const stats = getPropertyStats(selectedProperty);
               const requiredDocs = documentRequirements.filter(req => 
                 req.category === 'property' && 
@@ -561,7 +563,7 @@ export const DocumentsPage: React.FC = () => {
           ) : (
             <div className="grid gap-4">
               {filteredDocuments.map((doc) => {
-                const property = doc.propertyId ? mockProperties.find(p => p.id === doc.propertyId) : null;
+                const property = doc.propertyId ? properties.find(p => p.id === doc.propertyId) : null;
                 
                 return (
                   <Card key={doc.id} className="p-6">

--- a/src/pages/seller/PaymentsPage.tsx
+++ b/src/pages/seller/PaymentsPage.tsx
@@ -12,8 +12,7 @@ import {
 } from 'lucide-react';
 import { formatPrice } from '../../utils/calculations';
 import { cn } from '../../utils/cn';
-import { mockProperties } from '../../data/mockData';
-import { mockPayments } from "../../mocks";
+import { getProperties, getPayments } from "../../services/dataService";
 
 interface Payment {
   id: string;
@@ -160,9 +159,12 @@ export const PaymentsPage: React.FC = () => {
   const [showSavingsCalculator, setShowSavingsCalculator] = useState(false);
   const [selectedTab, setSelectedTab] = useState<'overview' | 'schedule' | 'history' | 'boost'>('overview');
 
+  const properties = getProperties();
+  const payments = getPayments();
+
   // Calculer les économies par bien
   const calculateSavings = (propertyId: string): Savings => {
-    const property = mockProperties.find(p => p.id === propertyId);
+    const property = properties.find(p => p.id === propertyId);
     if (!property) return { propertyId, traditionalFee: 0, loopImmoFee: 0, saved: 0, percentage: 0 };
 
     const traditionalFee = property.price * 0.05; // 5% en moyenne
@@ -174,23 +176,23 @@ export const PaymentsPage: React.FC = () => {
   };
 
   // Statistiques globales
-  const totalPaid = mockPayments
+  const totalPaid = payments
     .filter(p => p.status === 'completed')
     .reduce((sum, p) => sum + p.amount, 0);
 
-  const totalPending = mockPayments
+  const totalPending = payments
     .filter(p => p.status === 'scheduled' || p.status === 'pending')
     .reduce((sum, p) => sum + p.amount, 0);
 
-  const totalSavings = mockProperties.reduce((sum, property) => {
+  const totalSavings = properties.reduce((sum, property) => {
     const savings = calculateSavings(property.id);
     return sum + savings.saved;
   }, 0);
 
   // Filtrer les paiements
-  const filteredPayments = selectedProperty === 'all' 
-    ? mockPayments 
-    : mockPayments.filter(p => p.propertyId === selectedProperty);
+  const filteredPayments = selectedProperty === 'all'
+    ? payments
+    : payments.filter(p => p.propertyId === selectedProperty);
 
   const filteredSchedules = selectedProperty === 'all'
     ? paymentSchedules
@@ -231,7 +233,7 @@ export const PaymentsPage: React.FC = () => {
             </div>
             <div className="text-right">
               <p className="text-3xl font-bold text-green-600">{formatPrice(totalSavings)}</p>
-              <p className="text-sm text-gray-600 mt-1">économisés sur {mockProperties.length} biens</p>
+              <p className="text-sm text-gray-600 mt-1">économisés sur {properties.length} biens</p>
             </div>
           </div>
         </div>
@@ -245,7 +247,7 @@ export const PaymentsPage: React.FC = () => {
             Simulateur d'économies détaillé
           </h3>
           <div className="grid lg:grid-cols-2 gap-6">
-            {mockProperties.map((property) => {
+            {properties.map((property) => {
               const savings = calculateSavings(property.id);
               return (
                 <div key={property.id} className="bg-white rounded-lg p-4">
@@ -335,7 +337,7 @@ export const PaymentsPage: React.FC = () => {
                 <div>
                   <p className="text-sm text-gray-600">Économie moyenne</p>
                   <p className="text-2xl font-bold text-gray-900">
-                    {Math.round(totalSavings / mockProperties.length / 1000)}k€
+                    {Math.round(totalSavings / properties.length / 1000)}k€
                   </p>
                 </div>
               </div>
@@ -347,10 +349,10 @@ export const PaymentsPage: React.FC = () => {
             <div className="p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Prochains paiements</h3>
               <div className="space-y-3">
-                {mockPayments
+                {payments
                   .filter(p => p.status === 'scheduled' || p.status === 'pending')
                   .map((payment) => {
-                    const property = mockProperties.find(p => p.id === payment.propertyId);
+                    const property = properties.find(p => p.id === payment.propertyId);
                     return (
                       <div key={payment.id} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                         <div>
@@ -413,7 +415,7 @@ export const PaymentsPage: React.FC = () => {
             )}
 
             <div className="space-y-4">
-              {mockProperties.map((property) => {
+              {properties.map((property) => {
                 const propertySchedules = filteredSchedules.filter(s => s.propertyId === property.id);
                 return (
                   <div key={property.id} className="border rounded-lg p-4">
@@ -484,7 +486,7 @@ export const PaymentsPage: React.FC = () => {
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Historique des transactions</h3>
             <div className="space-y-3">
               {filteredPayments.map((payment) => {
-                const property = mockProperties.find(p => p.id === payment.propertyId);
+                const property = properties.find(p => p.id === payment.propertyId);
                 return (
                   <div key={payment.id} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
                     <div className="flex items-center gap-4">

--- a/src/pages/seller/PropertiesPage.tsx
+++ b/src/pages/seller/PropertiesPage.tsx
@@ -8,13 +8,13 @@ import {
   Camera, FileText, BarChart3, Trash2, Copy, Archive
 } from 'lucide-react';
 import { formatPrice } from '../../utils/calculations';
-import { mockProperties } from '../../data/mockData';
+import { getProperties } from '../../services/dataService';
 import { cn } from '../../utils/cn';
 
 export const PropertiesPage: React.FC = () => {
   const [filter, setFilter] = useState<'all' | 'active' | 'draft' | 'sold'>('all');
   
-  const properties = mockProperties.filter(p => p.sellerId === '1');
+  const properties = getProperties().filter(p => p.sellerId === '1');
   const filteredProperties = filter === 'all' 
     ? properties 
     : properties.filter(p => p.status === filter);

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,0 +1,84 @@
+const useMocks = import.meta.env.VITE_USE_MOCKS !== 'false';
+
+import {
+  mockProperties,
+  mockUsers,
+  mockAmbassadors,
+  PRICE_TIERS
+} from '../data/mockData';
+import {
+  mockServiceProviders,
+  mockServiceProposals,
+  subscriptionFeatures,
+  mockSubscriptions,
+  subscriptionPlans
+} from '../data/mockServiceProviders';
+import { mockReferrals, mockTerritoryProperties } from '../data/mockReferrals';
+import {
+  mockPayments,
+  mockContracts,
+  mockTimelines,
+  mockVisits,
+  mockZones,
+  mockCommissions,
+  mockPropertyPhotos,
+  mockProposals,
+  mockStats,
+  mockLeads,
+  mockDashboardCommissions,
+  mockManagedProperties,
+  mockEnrichedLeads
+} from '../mocks';
+
+function apiNotImplemented(name: string): never {
+  throw new Error(`API for ${name} not implemented`);
+}
+
+export const getProperties = () =>
+  useMocks ? mockProperties : apiNotImplemented('getProperties');
+export const getUsers = () =>
+  useMocks ? mockUsers : apiNotImplemented('getUsers');
+export const getAmbassadors = () =>
+  useMocks ? mockAmbassadors : apiNotImplemented('getAmbassadors');
+export const getPriceTiers = () =>
+  useMocks ? PRICE_TIERS : apiNotImplemented('getPriceTiers');
+export const getPayments = () =>
+  useMocks ? mockPayments : apiNotImplemented('getPayments');
+export const getContracts = () =>
+  useMocks ? mockContracts : apiNotImplemented('getContracts');
+export const getTimelines = () =>
+  useMocks ? mockTimelines : apiNotImplemented('getTimelines');
+export const getVisits = () =>
+  useMocks ? mockVisits : apiNotImplemented('getVisits');
+export const getZones = () =>
+  useMocks ? mockZones : apiNotImplemented('getZones');
+export const getCommissions = () =>
+  useMocks ? mockCommissions : apiNotImplemented('getCommissions');
+export const getPropertyPhotos = () =>
+  useMocks ? mockPropertyPhotos : apiNotImplemented('getPropertyPhotos');
+export const getProposals = () =>
+  useMocks ? mockProposals : apiNotImplemented('getProposals');
+export const getStats = () =>
+  useMocks ? mockStats : apiNotImplemented('getStats');
+export const getLeads = () =>
+  useMocks ? mockLeads : apiNotImplemented('getLeads');
+export const getDashboardCommissions = () =>
+  useMocks ? mockDashboardCommissions : apiNotImplemented('getDashboardCommissions');
+export const getManagedProperties = () =>
+  useMocks ? mockManagedProperties : apiNotImplemented('getManagedProperties');
+export const getEnrichedLeads = () =>
+  useMocks ? mockEnrichedLeads : apiNotImplemented('getEnrichedLeads');
+export const getReferrals = () =>
+  useMocks ? mockReferrals : apiNotImplemented('getReferrals');
+export const getTerritoryProperties = () =>
+  useMocks ? mockTerritoryProperties : apiNotImplemented('getTerritoryProperties');
+export const getServiceProviders = () =>
+  useMocks ? mockServiceProviders : apiNotImplemented('getServiceProviders');
+export const getServiceProposals = () =>
+  useMocks ? mockServiceProposals : apiNotImplemented('getServiceProposals');
+export const getSubscriptionFeatures = () =>
+  useMocks ? subscriptionFeatures : apiNotImplemented('getSubscriptionFeatures');
+export const getSubscriptions = () =>
+  useMocks ? mockSubscriptions : apiNotImplemented('getSubscriptions');
+export const getSubscriptionPlans = () =>
+  useMocks ? subscriptionPlans : apiNotImplemented('getSubscriptionPlans');

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,4 +1,6 @@
-import { PRICE_TIERS } from '../data/mockData';
+import { getPriceTiers } from '../services/dataService';
+
+const PRICE_TIERS = getPriceTiers();
 
 export function calculateFee(price: number) {
   const tier = PRICE_TIERS.find(t => price >= t.min && price <= t.max);


### PR DESCRIPTION
## Summary
- add `dataService` exposing functions like `getProperties` and `getPayments`
- switch components and pages to use the service instead of direct mock imports
- document the `VITE_USE_MOCKS` variable in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849f44e09fc83309c322029f22b996f