### PR TITLE
Add trust manager user role

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { 
-  Home, Building, Calendar, MessageSquare, FileText, 
+  Home, Building, Calendar, MessageSquare, FileText,
   Camera, BarChart3, CreditCard, LogOut, Menu, X,
   Search, Heart, Eye, Target, DollarSign, Users,
-  Briefcase, Award, Settings, HelpCircle, Zap, BookOpen
+  Briefcase, Award, Settings, HelpCircle, Zap, BookOpen,
+  CheckCircle, FileCheck, Shield
 } from 'lucide-react';
 import { RoleSelector } from '../layout/RoleSelector';
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
-  role: 'buyer' | 'seller' | 'ambassador';
+  role: 'buyer' | 'seller' | 'ambassador' | 'trust_manager';
 }
 
 export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, role }) => {
@@ -52,6 +53,16 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, role
       { name: 'Visites', href: '/ambassador/visits', icon: Calendar },
       { name: 'Commissions', href: '/ambassador/commissions', icon: DollarSign },
       { name: 'Formation', href: '/ambassador/training', icon: BookOpen },
+    ],
+    trust_manager: [
+      { name: 'Tableau de bord', href: '/trust-manager/dashboard', icon: Home },
+      { name: 'Tâches', href: '/trust-manager/tasks', icon: CheckCircle },
+      { name: 'Validation', href: '/trust-manager/validation', icon: FileCheck },
+      { name: 'Qualité', href: '/trust-manager/quality-control', icon: Eye },
+      { name: 'Leads', href: '/trust-manager/lead-qualification', icon: Users },
+      { name: 'Contrats', href: '/trust-manager/contracts', icon: FileText },
+      { name: 'Notaire', href: '/trust-manager/notary', icon: Briefcase },
+      { name: 'Conformité', href: '/trust-manager/compliance', icon: Shield },
     ],
   };
 

--- a/src/components/layout/NotificationCenter.tsx
+++ b/src/components/layout/NotificationCenter.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Bell, X, Home, Search, Users, Clock, CheckCircle } from 'lucide-react';
+import { Bell, X, Home, Search, Users, Clock, CheckCircle, Shield } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { UserRole } from '../../types';
 import { cn } from '../../utils/cn';
@@ -68,6 +68,15 @@ const mockNotifications: Notification[] = [
       label: 'Devenir ambassadeur',
       onClick: () => console.log('Navigate to ambassador signup')
     }
+  },
+  {
+    id: '6',
+    role: 'trust_manager',
+    title: 'Nouvelle tâche assignée',
+    message: 'Vérifier le dossier de la propriété 1234',
+    time: new Date(Date.now() - 1000 * 60 * 20),
+    read: false,
+    type: 'info'
   }
 ];
 
@@ -81,7 +90,8 @@ export const NotificationCenter: React.FC = () => {
   const roleIcons = {
     seller: Home,
     buyer: Search,
-    ambassador: Users
+    ambassador: Users,
+    trust_manager: Shield
   };
 
   const unreadCount = mockNotifications.filter(n => !n.read).length;

--- a/src/components/layout/RoleSelector.tsx
+++ b/src/components/layout/RoleSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { ChevronDown, Home, Search, Users, Plus, Bell } from 'lucide-react';
+import { ChevronDown, Home, Search, Users, Plus, Bell, Shield } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { UserRole } from '../../types';
 import { cn } from '../../utils/cn';
@@ -17,6 +17,7 @@ const roleOptions: RoleOption[] = [
   { role: 'seller', label: 'Mode Vendeur', icon: Home, path: '/seller/dashboard' },
   { role: 'buyer', label: 'Mode Acheteur', icon: Search, path: '/buyer/dashboard' },
   { role: 'ambassador', label: 'Mode Ambassadeur', icon: Users, path: '/ambassador/dashboard' },
+  { role: 'trust_manager', label: 'Mode Trust Manager', icon: Shield, path: '/trust-manager/dashboard' },
 ];
 
 export const RoleSelector: React.FC = () => {
@@ -35,7 +36,8 @@ export const RoleSelector: React.FC = () => {
   const notifications = {
     seller: 2,
     buyer: 0,
-    ambassador: 5
+    ambassador: 5,
+    trust_manager: 0
   };
 
   const handleRoleSwitch = (role: UserRole) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'buyer' | 'seller' | 'ambassador';
+export type UserRole = 'buyer' | 'seller' | 'ambassador' | 'trust_manager';
 
 export interface User {
   id: string;


### PR DESCRIPTION
## Summary
- support new `trust_manager` role
- show trust manager links in dashboard navigation
- update role selector and notifications for trust manager

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1f35d5e48330886e6237b2ac1d85