### PR TITLE
Add trust manager role option

### DIFF
--- a/src/components/layout/RoleSelector.tsx
+++ b/src/components/layout/RoleSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { ChevronDown, Home, Search, Users, Plus, Bell } from 'lucide-react';
+import { ChevronDown, Home, Search, Users, Plus, Bell, Shield } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { UserRole } from '../../types';
 import { cn } from '../../utils/cn';
@@ -17,6 +17,7 @@ const roleOptions: RoleOption[] = [
   { role: 'seller', label: 'Mode Vendeur', icon: Home, path: '/seller/dashboard' },
   { role: 'buyer', label: 'Mode Acheteur', icon: Search, path: '/buyer/dashboard' },
   { role: 'ambassador', label: 'Mode Ambassadeur', icon: Users, path: '/ambassador/dashboard' },
+  { role: 'trust_manager', label: 'Mode Trust Manager', icon: Shield, path: '/trust-manager/dashboard' },
 ];
 
 export const RoleSelector: React.FC = () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'buyer' | 'seller' | 'ambassador';
+export type UserRole = 'buyer' | 'seller' | 'ambassador' | 'trust_manager';
 
 export interface User {
   id: string;


### PR DESCRIPTION
## Summary
- enable trust manager role in role selector
- update role type definition

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684a1f3acc0c8330b486471ef7045455