### PR TITLE
Add trust manager role to mock data and layouts

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { 
-  Home, Building, Calendar, MessageSquare, FileText, 
+  Home, Building, Calendar, MessageSquare, FileText,
   Camera, BarChart3, CreditCard, LogOut, Menu, X,
   Search, Heart, Eye, Target, DollarSign, Users,
-  Briefcase, Award, Settings, HelpCircle, Zap, BookOpen
+  Briefcase, Award, Settings, HelpCircle, Zap, BookOpen,
+  FileCheck, Archive, Shield
 } from 'lucide-react';
 import { RoleSelector } from '../layout/RoleSelector';
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
-  role: 'buyer' | 'seller' | 'ambassador';
+  role: 'buyer' | 'seller' | 'ambassador' | 'trust_manager';
 }
 
 export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, role }) => {
@@ -52,6 +53,16 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, role
       { name: 'Visites', href: '/ambassador/visits', icon: Calendar },
       { name: 'Commissions', href: '/ambassador/commissions', icon: DollarSign },
       { name: 'Formation', href: '/ambassador/training', icon: BookOpen },
+    ],
+    trust_manager: [
+      { name: 'Dashboard', href: '/trust-manager/home', icon: Home },
+      { name: 'Tâches', href: '/trust-manager/tasks', icon: Calendar },
+      { name: 'Validation', href: '/trust-manager/validation', icon: FileCheck },
+      { name: 'Qualité', href: '/trust-manager/quality-control', icon: Camera },
+      { name: 'Leads', href: '/trust-manager/lead-qualification', icon: Users },
+      { name: 'Contrats', href: '/trust-manager/contracts', icon: FileText },
+      { name: 'Notaire', href: '/trust-manager/notary', icon: Archive },
+      { name: 'Conformité', href: '/trust-manager/compliance', icon: Shield },
     ],
   };
 

--- a/src/components/layout/NotificationCenter.tsx
+++ b/src/components/layout/NotificationCenter.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Bell, X, Home, Search, Users, Clock, CheckCircle } from 'lucide-react';
+import { Bell, X, Home, Search, Users, Clock, CheckCircle, Shield } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { UserRole } from '../../types';
 import { cn } from '../../utils/cn';
@@ -81,7 +81,8 @@ export const NotificationCenter: React.FC = () => {
   const roleIcons = {
     seller: Home,
     buyer: Search,
-    ambassador: Users
+    ambassador: Users,
+    trust_manager: Shield
   };
 
   const unreadCount = mockNotifications.filter(n => !n.read).length;

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -337,6 +337,15 @@ export const mockUsers: User[] = [
     roles: ['ambassador'],
     phone: '0698765436',
     createdAt: new Date('2023-12-20')
+  },
+  {
+    id: 'trust1',
+    email: 'trust@test.com',
+    firstName: 'Alice',
+    lastName: 'Trusted',
+    roles: ['trust_manager'],
+    phone: '0600000000',
+    createdAt: new Date('2024-01-10')
   }
 ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'buyer' | 'seller' | 'ambassador';
+export type UserRole = 'buyer' | 'seller' | 'ambassador' | 'trust_manager';
 
 export interface User {
   id: string;


### PR DESCRIPTION
## Summary
- add trust manager mock user
- support new `trust_manager` role in type definitions
- show trust manager pages in `DashboardLayout`
- display trust manager icon in NotificationCenter

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a1f3a14e8833096b30fee07183a3f