### PR TITLE
Fix Trust Manager Dashboard routing

### DIFF
--- a/src/pages/trust-manager/TrustManagerDashboard.tsx
+++ b/src/pages/trust-manager/TrustManagerDashboard.tsx
@@ -14,8 +14,8 @@ export const TrustManagerDashboard: React.FC = () => {
   return (
     <DashboardLayout role="trust_manager">
       <Routes>
-        <Route index element={<Navigate to="home" replace />} />
-        <Route path="home" element={<TrustManagerHome />} />
+        <Route index element={<Navigate to="/trust-manager/dashboard" replace />} />
+        <Route path="dashboard" element={<TrustManagerHome />} />
         <Route path="tasks" element={<TasksOverview />} />
         <Route path="validation" element={<PropertyValidation />} />
         <Route path="quality-control" element={<QualityControl />} />


### PR DESCRIPTION
## Summary
- fix dashboard home route for Trust Manager

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684a80eb1bf883308c2b574566252d43