### PR TITLE
Add basic Express server for PostgreSQL

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,4 @@
 VITE_USE_MOCKS = true
+
+# PostgreSQL configuration
+DATABASE_URL=postgres://user:password@localhost:5432/loopimmo

--- a/README.md
+++ b/README.md
@@ -61,3 +61,19 @@ psql "$DATABASE_URL" -f sql/sample_data.sql
 ```
 
 Replace `$DATABASE_URL` with your connection string. The scripts can be executed against any PostgreSQL instance, including cloud providers.
+
+## Backend server
+
+A minimal Express server located in the `server` directory exposes REST endpoints backed by PostgreSQL. Ensure you have loaded the schema and sample data, then add your database connection string to `.env.local`:
+
+```bash
+DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
+```
+
+Start the server with:
+
+```bash
+npm run server
+```
+
+The API listens on port `3000` by default and currently exposes `/api/users` and `/api/properties` routes.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "ts-node server/src/index.ts"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -21,7 +22,10 @@
     "tailwind-merge": "^2.2.1",
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
-    "@types/leaflet": "^1.9.8"
+    "@types/leaflet": "^1.9.8",
+    "express": "^4.19.2",
+    "pg": "^8.11.3",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -37,6 +41,9 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "ts-node": "^10.9.1",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.9"
   }
 }

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+# PostgreSQL connection URL
+DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
+
+# Optional: server port
+# PORT=3000

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,10 @@
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const query = (text: string, params?: any[]) => pool.query(text, params);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import { query } from './db';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.get('/api/users', async (_req, res) => {
+  try {
+    const { rows } = await query('SELECT * FROM users');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+app.get('/api/properties', async (_req, res) => {
+  try {
+    const { rows } = await query('SELECT * FROM properties');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add minimal Express server in `server` folder
- connect to PostgreSQL with `pg`
- expose `/api/users` and `/api/properties` endpoints
- document how to run the server and update env variables
- add server dependencies and script

## Testing
- `npx tsc -p server/tsconfig.json` *(fails: cannot find module types)*

------
https://chatgpt.com/codex/tasks/task_e_684ad7c1df348330bbee28423d29fda9