### PR TITLE
Fix server start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,7 @@ Start the server with:
 npm run server
 ```
 
+The script relies on `ts-node`'s ESM loader (via `ts-node-esm`), so ensure you
+are running Node.js 18 or later.
+
 The API listens on port `3000` by default and currently exposes `/api/users` and `/api/properties` routes.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "ts-node server/src/index.ts"
+    "server": "ts-node-esm server/src/index.ts"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",


### PR DESCRIPTION
## Summary
- update server script to use `ts-node-esm`
- document requirement for Node >=18

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b43f831d88330958c6a31eafd14f1