### PR TITLE
Add property detail API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ The script relies on `ts-node`'s ESM loader (via `ts-node-esm`). It uses the
 set using [`cross-env`](https://www.npmjs.com/package/cross-env), so ensure you
 are running Node.js 18 or later.
 
-The API listens on port `3000` by default and currently exposes `/api/users` and `/api/properties` routes.
+The API listens on port `3000` by default and currently exposes `/api/users`, `/api/properties`, and `/api/properties/:id` routes.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,6 +26,29 @@ app.get('/api/properties', async (_req, res) => {
   }
 });
 
+app.get('/api/properties/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { rows } = await query(
+      `SELECT p.*, u.first_name AS seller_first_name, u.last_name AS seller_last_name,
+              a.id AS ambassador_id, a.bio AS ambassador_bio
+       FROM properties p
+       LEFT JOIN users u ON p.seller_id = u.id
+       LEFT JOIN ambassadors a ON p.ambassador_id = a.id
+       WHERE p.id = $1`,
+      [id],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Property not found' });
+    } else {
+      res.json(rows[0]);
+    }
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 app.listen(port, () => {
   console.log(`Server listening on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- add `/api/properties/:id` route with joins to `users` and `ambassadors`
- document the new route in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4e1634ac8330b129cf62a71bc40c