### PR TITLE
Add newsletter email signup

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,11 @@ VITE_LAUNCH_MODE=true
 
 # PostgreSQL configuration
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
+
+# Email configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+EMAIL_FROM=noreply@example.com
+EMAIL_TO=admin@example.com

--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ VITE_LAUNCH_MODE=true
 
 # PostgreSQL configuration
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
+
+# Email configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+EMAIL_FROM=noreply@example.com
+EMAIL_TO=admin@example.com

--- a/.env.local
+++ b/.env.local
@@ -2,3 +2,11 @@ VITE_USE_MOCKS = true
 
 # PostgreSQL configuration
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
+
+# Email configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+EMAIL_FROM=noreply@example.com
+EMAIL_TO=admin@example.com

--- a/README.md
+++ b/README.md
@@ -82,3 +82,16 @@ set using [`cross-env`](https://www.npmjs.com/package/cross-env), so ensure you
 are running Node.js 18 or later.
 
 The API listens on port `3000` by default and currently exposes `/api/users` and `/api/properties` routes.
+
+### Email configuration
+
+To enable email confirmations for newsletter signups, add your SMTP details in `.env.local` (or `.env` for production):
+
+```bash
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_username
+SMTP_PASS=your_password
+EMAIL_FROM=noreply@example.com
+EMAIL_TO=admin@example.com
+```

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@types/leaflet": "^1.9.8",
     "express": "^4.19.2",
     "pg": "^8.11.3",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/.env
+++ b/server/.env
@@ -1,5 +1,13 @@
 # PostgreSQL connection URL
 DATABASE_URL=postgres://adminBolt:5lP0LkvqXmK6NJasIw87@postgresql-b9be9228-o763a27ec.database.cloud.ovh.net:20184/loopimmo?sslmode=require
 
+# Email configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+EMAIL_FROM=noreply@example.com
+EMAIL_TO=admin@example.com
+
 # Optional: server port
 # PORT=3000

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "pg": "^8.11.3",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/server/src/handlers/index.ts
+++ b/server/src/handlers/index.ts
@@ -12,3 +12,4 @@ export * from './analytics';
 export * from './messages';
 export * from './payments';
 export * from './system';
+export * from './newsletter';

--- a/server/src/handlers/newsletter.ts
+++ b/server/src/handlers/newsletter.ts
@@ -1,0 +1,45 @@
+import { Request, Response } from 'express';
+import nodemailer from 'nodemailer';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
+
+export const subscribeNewsletter = async (req: Request, res: Response) => {
+  const { email } = req.body as { email?: string };
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT),
+      secure: Number(process.env.SMTP_PORT) === 465,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: email,
+      subject: 'Confirmation d\'inscription',
+      text: 'Merci pour votre inscription à LoopImmo!',
+    });
+
+    if (process.env.EMAIL_TO) {
+      await transporter.sendMail({
+        from: process.env.EMAIL_FROM,
+        to: process.env.EMAIL_TO,
+        subject: 'Nouvelle inscription',
+        text: `Nouvelle inscription : ${email}`,
+      });
+    }
+
+    res.status(200).json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Unable to send email' });
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { query } from './db';
+import { subscribeNewsletter } from './handlers';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -25,6 +26,8 @@ app.get('/api/properties', async (_req, res) => {
     res.status(500).json({ error: 'Internal server error' });
   }
 });
+
+app.post('/api/subscribe', subscribeNewsletter);
 
 app.listen(port, () => {
   console.log(`Server listening on port ${port}`);

--- a/src/pages/LaunchPage.tsx
+++ b/src/pages/LaunchPage.tsx
@@ -9,12 +9,22 @@ export const LaunchPage: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
-    
-    // Simuler l'envoi (à remplacer par un vrai appel API)
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    setIsSubmitted(true);
-    setIsLoading(false);
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) {
+        throw new Error('Request failed');
+      }
+      setIsSubmitted(true);
+    } catch (err) {
+      console.error(err);
+      alert("Erreur lors de l'inscription");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,12 @@
 interface ImportMetaEnv {
   readonly VITE_LAUNCH_MODE: string
   readonly DATABASE_URL: string
+  readonly SMTP_HOST: string
+  readonly SMTP_PORT: string
+  readonly SMTP_USER: string
+  readonly SMTP_PASS: string
+  readonly EMAIL_FROM: string
+  readonly EMAIL_TO: string
   // Ajouter d'autres variables d'environnement ici si nécessaire
 }
 


### PR DESCRIPTION
## Summary
- add SMTP vars to `.env` files
- document email configuration
- type new environment variables
- implement `/api/subscribe` endpoint
- send signup request from `LaunchPage`
- depend on nodemailer for sending mail

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851dbdf50548330adf90a53173fad85