### PR TITLE
Set proxy URL via env variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+# Mettre l'adresse du serveur backend utilisee par Vite
+VITE_API_URL=http://localhost:3000
 VITE_LAUNCH_MODE=true
 # Mettre à false pour afficher la page d'accueil traditionnelle
 # Mettre à true pour afficher la landing page de lancement

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 VITE_LAUNCH_MODE=true
+# Adresse du serveur backend utilisée en développement
+VITE_API_URL=http://localhost:3000
 # true = Landing page de lancement (avant le 1er septembre)
 # false = Page d'accueil traditionnelle (après le lancement)
 

--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,4 @@
+VITE_API_URL=http://localhost:3000
 VITE_USE_MOCKS = true
 
 # PostgreSQL configuration

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Start the development server with hot reload:
 npm run dev
 ```
 
+The frontend expects the API to be available on the URL specified by
+`VITE_API_URL` (default `http://localhost:3000`). When working locally, start the
+Express backend in another terminal:
+
+```bash
+npm run server
+```
+
+Vite is configured to proxy `/api` requests to this server during development.
+The proxy target is read from the `VITE_API_URL` variable.
+
 Build for production:
 
 ```bash

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd())
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': env.VITE_API_URL || 'http://localhost:3000',
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- load API URL from `VITE_API_URL` in Vite config
- document proxy variable in README
- update sample environment files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852af5a50448330a5d8fe2092a12459