### PR TITLE
Set proxy URL via env variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+# Mettre l'adresse du serveur backend utilisee par Vite
+VITE_API_URL=http://localhost:3000
 VITE_LAUNCH_MODE=true
 # Mettre à false pour afficher la page d'accueil traditionnelle
 # Mettre à true pour afficher la landing page de lancement
@@ -5,10 +7,3 @@ VITE_LAUNCH_MODE=true
 # PostgreSQL configuration
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
 
-# Email configuration
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=username
-SMTP_PASS=password
-EMAIL_FROM=noreply@example.com
-EMAIL_TO=admin@example.com

--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,9 @@
 VITE_LAUNCH_MODE=true
+# Adresse du serveur backend utilisée en développement
+VITE_API_URL=http://localhost:3000
 # true = Landing page de lancement (avant le 1er septembre)
 # false = Page d'accueil traditionnelle (après le lancement)
 
 # PostgreSQL configuration
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
 
-# Email configuration
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=username
-SMTP_PASS=password
-EMAIL_FROM=noreply@example.com
-EMAIL_TO=admin@example.com

--- a/.env.local
+++ b/.env.local
@@ -1,12 +1,6 @@
+VITE_API_URL=http://localhost:3000
 VITE_USE_MOCKS = true
 
 # PostgreSQL configuration
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
 
-# Email configuration
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=username
-SMTP_PASS=password
-EMAIL_FROM=noreply@example.com
-EMAIL_TO=admin@example.com

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Start the development server with hot reload:
 npm run dev
 ```
 
+The frontend expects the API to be available on the URL specified by
+`VITE_API_URL` (default `http://localhost:3000`). When working locally, start the
+Express backend in another terminal:
+
+```bash
+npm run server
+```
+
+Vite is configured to proxy `/api` requests to this server during development.
+The proxy target is read from the `VITE_API_URL` variable.
+
 Build for production:
 
 ```bash
@@ -85,13 +96,5 @@ The API listens on port `3000` by default and currently exposes `/api/users` and
 
 ### Email configuration
 
-To enable email confirmations for newsletter signups, add your SMTP details in `.env.local` (or `.env` for production):
-
-```bash
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=your_username
-SMTP_PASS=your_password
-EMAIL_FROM=noreply@example.com
-EMAIL_TO=admin@example.com
-```
+The SMTP credentials used to send confirmation emails are stored in `server/.env` on
+the backend server. Edit that file (or `server/.env.example`) to match your environment.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,13 @@
 # PostgreSQL connection URL
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
 
+# Email configuration
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=username
+# SMTP_PASS=password
+# EMAIL_FROM=noreply@example.com
+# EMAIL_TO=admin@example.com
+
 # Optional: server port
 # PORT=3000

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,13 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_LAUNCH_MODE: string
+  readonly VITE_API_URL?: string
   readonly DATABASE_URL: string
-  readonly SMTP_HOST: string
-  readonly SMTP_PORT: string
-  readonly SMTP_USER: string
-  readonly SMTP_PASS: string
-  readonly EMAIL_FROM: string
-  readonly EMAIL_TO: string
   // Ajouter d'autres variables d'environnement ici si nécessaire
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd())
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': env.VITE_API_URL || 'http://localhost:3000',
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- load API URL from `VITE_API_URL` in Vite config
- document proxy variable in README
- update sample environment files
- remove frontend SMTP config so only the backend uses it

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852af5a50448330a5d8fe2092a12459