### PR TITLE
Skip email if SMTP unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Express backend in another terminal:
 ```bash
 npm run server
 ```
+Run this command from the project root so that the `cross-env` dependency can be
+resolved correctly.
 
 Vite is configured to proxy `/api` requests to this server during development.
 The proxy target is read from the `VITE_API_URL` variable.
@@ -75,7 +77,7 @@ Replace `$DATABASE_URL` with your connection string. The scripts can be executed
 
 ## Backend server
 
-A minimal Express server located in the `server` directory exposes REST endpoints backed by PostgreSQL. Ensure you have loaded the schema and sample data, then add your database connection string to `.env.local`:
+A minimal Express server located in the `server` directory exposes REST endpoints backed by PostgreSQL. Ensure you have loaded the schema and sample data, then add your database connection string to `server/.env`:
 
 ```bash
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
@@ -87,7 +89,7 @@ Start the server with:
 npm run server
 ```
 
-The script relies on `ts-node`'s ESM loader (via `ts-node-esm`). It uses the
+The script runs `ts-node` and uses the
 `server/tsconfig.json` project via the `TS_NODE_PROJECT` environment variable,
 set using [`cross-env`](https://www.npmjs.com/package/cross-env), so ensure you
 are running Node.js 18 or later.
@@ -98,3 +100,5 @@ The API listens on port `3000` by default and currently exposes `/api/users` and
 
 The SMTP credentials used to send confirmation emails are stored in `server/.env` on
 the backend server. Edit that file (or `server/.env.example`) to match your environment.
+If these variables are missing, the newsletter endpoint simply logs a warning and
+does not attempt to send email, which avoids a 500 error during local testing.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "cross-env TS_NODE_PROJECT=server/tsconfig.json ts-node-esm server/src/index.ts"
+    "server": "cross-env TS_NODE_PROJECT=server/tsconfig.json ts-node server/src/index.ts"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -46,6 +46,7 @@
     "ts-node": "^10.9.1",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.9",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "@types/nodemailer": "^6.4.7"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "nodemon": "^3.0.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@types/nodemailer": "^6.4.7"
   }
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,7 +1,9 @@
 import { Pool } from 'pg';
+import path from 'path';
 import dotenv from 'dotenv';
 
-dotenv.config({ path: '.env.local' });
+// Load server-specific environment variables
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,

--- a/server/src/handlers/newsletter.ts
+++ b/server/src/handlers/newsletter.ts
@@ -1,8 +1,10 @@
 import { Request, Response } from 'express';
 import nodemailer from 'nodemailer';
+import path from 'path';
 import dotenv from 'dotenv';
 
-dotenv.config({ path: '.env.local' });
+// Load server-specific environment variables for email credentials
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 export const subscribeNewsletter = async (req: Request, res: Response) => {
   const { email } = req.body as { email?: string };
@@ -13,33 +15,45 @@ export const subscribeNewsletter = async (req: Request, res: Response) => {
   const referralCode = Math.random().toString(36).slice(2, 8).toUpperCase();
 
   try {
-    const transporter = nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: Number(process.env.SMTP_PORT),
-      secure: Number(process.env.SMTP_PORT) === 465,
-      auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS,
-      },
-    });
+    const smtpReady =
+      process.env.SMTP_HOST &&
+      process.env.SMTP_USER &&
+      process.env.SMTP_PASS &&
+      process.env.SMTP_HOST !== 'smtp.example.com';
 
-    await transporter.sendMail({
-      from: process.env.EMAIL_FROM,
-      to: email,
-      subject: "Confirmation d'inscription",
-      text: `Merci pour votre inscription à LoopImmo!\nVoici votre code de parrainage : ${referralCode}\nPartagez-le avec vos contacts pour cumuler des primes.`,
-    });
-
-    if (process.env.EMAIL_TO) {
-      await transporter.sendMail({
-        from: process.env.EMAIL_FROM,
-        to: process.env.EMAIL_TO,
-        subject: 'Nouvelle inscription',
-        text: `Nouvelle inscription : ${email} - Code ${referralCode}`,
+    let transporter: nodemailer.Transporter | undefined;
+    if (smtpReady) {
+      transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port: Number(process.env.SMTP_PORT),
+        secure: Number(process.env.SMTP_PORT) === 465,
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        },
       });
+    } else {
+      console.warn('SMTP not configured, skipping email send');
     }
 
-    res.status(200).json({ success: true, referralCode });
+    if (transporter) {
+      await transporter.sendMail({
+        from: process.env.EMAIL_FROM,
+        to: email,
+        subject: "Confirmation d'inscription",
+        text: `Merci pour votre inscription à LoopImmo!\nVoici votre code de parrainage : ${referralCode}\nPartagez-le avec vos contacts pour cumuler des primes.`,
+      });
+
+      if (process.env.EMAIL_TO) {
+        await transporter.sendMail({
+          from: process.env.EMAIL_FROM,
+          to: process.env.EMAIL_TO,
+          subject: 'Nouvelle inscription',
+          text: `Nouvelle inscription : ${email} - Code ${referralCode}`,
+        });
+      }
+    }
+    res.status(200).json({ success: true, referralCode, emailSent: !!transporter });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Unable to send email' });


### PR DESCRIPTION
## Summary
- avoid 500 errors when SMTP credentials aren't configured
- mention running `npm run server` from the project root
- explain that emails are skipped if SMTP settings are missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852b92d27c48330bd287180a5350932