### PR TITLE
Fix newsletter env path

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,12 @@ The SMTP credentials used to send confirmation emails are stored in `server/.env
 the backend server. Edit that file (or `server/.env.example`) to match your environment.
 If these variables are missing, the newsletter endpoint simply logs a warning and
 does not attempt to send email, which avoids a 500 error during local testing.
+If you set the variables to dummy values without a real SMTP server (for example
+`SMTP_HOST=localhost`), nodemailer will try to connect and the server may output an
+`ECONNREFUSED 127.0.0.1:587` error. Either configure valid credentials or remove the
+SMTP entries from `.env` so emails are skipped during development.
+
+This port `587` belongs to your email server, not the API. Even if `VITE_API_URL` points
+to `http://localhost:3000`, you still need a mail service listening on
+`localhost:587`. Without one, simply omit the `SMTP_*` variables so that email
+sending is skipped entirely.

--- a/server/src/handlers/newsletter.ts
+++ b/server/src/handlers/newsletter.ts
@@ -4,7 +4,9 @@ import path from 'path';
 import dotenv from 'dotenv';
 
 // Load server-specific environment variables for email credentials
-dotenv.config({ path: path.resolve(__dirname, '../.env') });
+// The handler lives in `server/src/handlers`, so the root `.env`
+// resides two directories up from this file.
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 export const subscribeNewsletter = async (req: Request, res: Response) => {
   const { email } = req.body as { email?: string };


### PR DESCRIPTION
## Summary
- load the root `.env` from `newsletter.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852c6dd150883309e3aa1c059f018ca