### PR TITLE
Fix self-signed cert error in DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ are running Node.js 18 or later.
 
 The API listens on port `3000` by default and currently exposes `/api/users` and `/api/properties` routes.
 
+If your `DATABASE_URL` contains `sslmode=require` for a cloud database using a
+self-signed certificate, the server automatically disables certificate
+verification so that `pg` can connect without errors.
+
 ### Email configuration
 
 The SMTP credentials used to send confirmation emails are stored in `server/.env` on

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -5,8 +5,12 @@ import dotenv from 'dotenv';
 // Load server-specific environment variables
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
+const connectionString = process.env.DATABASE_URL;
+const sslRequired = connectionString?.includes('sslmode=require');
+
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString,
+  ...(sslRequired ? { ssl: { rejectUnauthorized: false } } : {}),
 });
 
 export const query = (text: string, params?: any[]) => pool.query(text, params);


### PR DESCRIPTION
## Summary
- allow pg to connect when DATABASE_URL uses sslmode=require
- document the sslmode behaviour in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531b7f7a1c8330a889ac2ca96990b5