### PR TITLE
Fix self-signed certificate error

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -8,6 +8,14 @@ dotenv.config({ path: path.resolve(__dirname, '../.env') });
 const connectionString = process.env.DATABASE_URL;
 const sslRequired = connectionString?.includes('sslmode=require');
 
+if (sslRequired) {
+  // Disable TLS certificate verification when connecting to cloud
+  // databases that provide a self-signed certificate. This mirrors the
+  // behaviour of setting NODE_TLS_REJECT_UNAUTHORIZED=0 but only applies
+  // when the connection string explicitly requests SSL.
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+}
+
 const pool = new Pool({
   connectionString,
   ...(sslRequired ? { ssl: { rejectUnauthorized: false } } : {}),


### PR DESCRIPTION
## Summary
- disable TLS verification when `sslmode=require` is present

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531cbb52ac83309b9a1e5deb7ef4e2