### PR TITLE
Handle duplicate emails on LaunchPage signup

### DIFF
--- a/server/src/handlers/newsletter.ts
+++ b/server/src/handlers/newsletter.ts
@@ -20,6 +20,16 @@ export const subscribeNewsletter = async (req: Request, res: Response) => {
     return res.status(400).json({ error: 'Email is required' });
   }
 
+  try {
+    const { rows } = await query('SELECT id FROM users WHERE email = $1', [email]);
+    if (rows.length > 0) {
+      return res.status(409).json({ error: 'Email already exists' });
+    }
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Unable to check email' });
+  }
+
   const referralCode = Math.random().toString(36).slice(2, 8).toUpperCase();
   const baseUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
   const referralLink = `${baseUrl}?ref=${referralCode}`;

--- a/src/pages/LaunchPage.tsx
+++ b/src/pages/LaunchPage.tsx
@@ -60,6 +60,10 @@ export const LaunchPage: React.FC = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, role, referredBy }),
       });
+      if (res.status === 409) {
+        setEmailError("Cet email est déjà enregistré");
+        return;
+      }
       if (!res.ok) {
         throw new Error("Request failed");
       }


### PR DESCRIPTION
## Summary
- reject duplicate emails in `subscribeNewsletter`
- surface duplication error on `LaunchPage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_685333c9f99c8330b86c89cfd9486931