### PR TITLE
Fix newsletter mailer typo

### DIFF
--- a/server/src/handlers/newsletter.ts
+++ b/server/src/handlers/newsletter.ts
@@ -60,7 +60,7 @@ export const subscribeNewsletter = async (req: Request, res: Response) => {
 
     let transporter: nodemailer.Transporter | undefined;
     if (smtpReady) {
-      transporter = nodemailer.createTransporter({
+      transporter = nodemailer.createTransport({
         host: process.env.SMTP_HOST,
         port: Number(process.env.SMTP_PORT),
         secure: Number(process.env.SMTP_PORT) === 465,


### PR DESCRIPTION
## Summary
- fix incorrect `nodemailer.createTransporter` call

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533db0ede88330a80ab7cb26195ccf