### PR TITLE
Add start script and prestart build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "cross-env TS_NODE_PROJECT=server/tsconfig.json ts-node server/src/index.ts"
+    "server": "cross-env TS_NODE_PROJECT=server/tsconfig.json ts-node server/src/index.ts",
+    "prestart": "npm --prefix server run build",
+    "start": "node server/dist/index.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",


### PR DESCRIPTION
## Summary
- start compiled server code with `npm start`
- ensure server build runs via prestart hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fe3fe60083309ba968394802071f