### PR TITLE
Fix LaunchPageV2 component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
           } />
           
           {/* Route dédiée pour tester la V2 */}
-          <Route path="/v2" element={<LandingPageV2 />} />
+          <Route path="/v2" element={<LaunchPageV2 />} />
           
           {/* Autres pages publiques */}
           <Route path="/login" element={<LoginPage />} />

--- a/src/pages/LaunchPageV2.tsx
+++ b/src/pages/LaunchPageV2.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ArrowRight, Users, TrendingDown, Shield, Home, Search, Euro, Clock, CheckCircle, Star, Heart, Zap, Award, UserCheck, FileCheck, Handshake, ArrowDown } from 'lucide-react';
 
-export const LandingPageV2: React.FC = () => {
+export const LaunchPageV2: React.FC = () => {
   const [email, setEmail] = useState('');
 
   const handleEmailSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- fix export name in `LaunchPageV2.tsx`
- use `LaunchPageV2` component in routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685536117bd88330be843df737946d8c