### PR TITLE
Add Sentry dependency to server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,8 @@
     "pg": "^8.11.3",
     "dotenv": "^16.3.1",
     "nodemailer": "^6.9.11",
-    "qrcode": "^1.5.3"
+    "qrcode": "^1.5.3",
+    "@sentry/node": "^7.98.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",


### PR DESCRIPTION
## Summary
- include `@sentry/node` in `server/package.json`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6859d065297c8330bb9a7c9245c872c5