### PR TITLE
Fix TLS warning when starting server

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -9,13 +9,9 @@ dotenv.config({ path: path.resolve(__dirname, '../.env') });
 const connectionString = process.env.DATABASE_URL;
 const sslRequired = connectionString?.includes('sslmode=require');
 
-if (sslRequired) {
-  // Disable TLS certificate verification when connecting to cloud
-  // databases that provide a self-signed certificate. This mirrors the
-  // behaviour of setting NODE_TLS_REJECT_UNAUTHORIZED=0 but only applies
-  // when the connection string explicitly requests SSL.
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-}
+// When the connection string requires SSL, skip certificate verification
+// for the database connection only. Avoid setting
+// NODE_TLS_REJECT_UNAUTHORIZED globally to prevent runtime warnings.
 
 const pool = new Pool({
   connectionString,


### PR DESCRIPTION
## Summary
- remove `NODE_TLS_REJECT_UNAUTHORIZED` override in db config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e515c2fc83308f15270b6e342a18