### PR TITLE
Fix missing cors types

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -31,6 +31,7 @@
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "@types/nodemailer": "^6.4.7",
-    "@types/qrcode": "^1.5.0"
+    "@types/qrcode": "^1.5.0",
+    "@types/cors": "^2.8.17"
   }
 }


### PR DESCRIPTION
## Summary
- add `@types/cors` to server dev dependencies

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a502f52ac8330aa1dc5b46d12e1da