### PR TITLE
Add env file check

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -3,8 +3,14 @@ import path from 'path';
 import dotenv from 'dotenv';
 import { log, error } from './utils/logger';
 
-// Load server-specific environment variables
-dotenv.config({ path: path.resolve(__dirname, '../.env') });
+// Load server-specific environment variables and log the result
+const envPath = path.resolve(__dirname, '../.env');
+const envResult = dotenv.config({ path: envPath });
+if (envResult.error) {
+  log(`No .env file found at ${envPath}`);
+} else {
+  log(`Loaded environment variables from ${envPath}`);
+}
 
 const connectionString = process.env.DATABASE_URL;
 const sslRequired = connectionString?.includes('sslmode=require');

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -1,14 +1,14 @@
-export const isDebug = process.env.DEBUG === 'true';
+export const isDebug = () => process.env.DEBUG === 'true';
 
 export const log = (...args: unknown[]) => {
-  if (isDebug) {
+  if (isDebug()) {
     // eslint-disable-next-line no-console
     console.log(...args);
   }
 };
 
 export const error = (...args: unknown[]) => {
-  if (isDebug) {
+  if (isDebug()) {
     // eslint-disable-next-line no-console
     console.error(...args);
   }


### PR DESCRIPTION
## Summary
- check for `server/.env` when starting the server
- log env loading result
- make debug logging check dynamic

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5140fec483309fcb9c2679fa0c7f