### PR TITLE
Implement referral auto-fill

### DIFF
--- a/src/pages/LaunchPageV2.tsx
+++ b/src/pages/LaunchPageV2.tsx
@@ -1,11 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ArrowRight, Users, TrendingDown, Shield, Home, Search, Euro, Clock, CheckCircle, Star, Heart, Zap, Award, UserCheck, FileCheck, Handshake, ArrowDown, Gift, Percent, UserPlus, Copy, Check, Info, X, Share2 } from 'lucide-react';
 
 export const LaunchPageV2: React.FC = () => {
+  const [searchParams] = useSearchParams();
   const [email, setEmail] = useState('');
   const [referralCode, setReferralCode] = useState('');
   const [showReferralSuccess, setShowReferralSuccess] = useState(false);
   const [showReferralPopup, setShowReferralPopup] = useState(false);
+
+  useEffect(() => {
+    const ref = searchParams.get('ref');
+    if (ref) {
+      setReferralCode(ref);
+    }
+  }, [searchParams]);
 
 
   const validateEmail = (value: string) => {


### PR DESCRIPTION
## Summary
- auto detect `ref` query param in LaunchPageV2
- send the referral code when subscribing

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a61e1e168833086bd2141079b7d17