### PR TITLE
Add role field to newsletter signup

### DIFF
--- a/server/src/handlers/newsletter.ts
+++ b/server/src/handlers/newsletter.ts
@@ -13,11 +13,12 @@ import { log, error } from '../utils/logger';
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 export const subscribeNewsletter = async (req: Request, res: Response) => {
-  const { email, referredBy } = req.body as {
+  const { email, referredBy, role } = req.body as {
     email?: string;
     referredBy?: string;
+    role?: string;
   };
-  log('subscribeNewsletter called', { email, referredBy });
+  log('subscribeNewsletter called', { email, referredBy, role });
   if (!email) {
     return res.status(400).json({ error: 'Email is required' });
   }
@@ -49,7 +50,7 @@ export const subscribeNewsletter = async (req: Request, res: Response) => {
         email,
         '',
         '',
-        [],
+        role ? [role] : [],
         null,
         null,
         referralCode,
@@ -381,12 +382,13 @@ export const subscribeNewsletter = async (req: Request, res: Response) => {
           from: process.env.EMAIL_FROM,
           to: process.env.EMAIL_TO,
           subject: '🎯 Nouvelle inscription LoopImmo',
-          text: `Nouvelle inscription sur LoopImmo !\n\nEmail : ${email}\nCode de parrainage : ${referralCode}${referredBy ? `\nParrainé par : ${referredBy}` : ''}\n\nTableau de bord admin pour plus de détails.`,
+          text: `Nouvelle inscription sur LoopImmo !\n\nEmail : ${email}\nRole : ${role || 'n/a'}\nCode de parrainage : ${referralCode}${referredBy ? `\nParrainé par : ${referredBy}` : ''}\n\nTableau de bord admin pour plus de détails.`,
           html: `
             <div style="font-family: Arial, sans-serif; max-width: 500px; margin: 0 auto; padding: 20px; background: #f8fafc; border-radius: 8px;">
               <h2 style="color: #2d3748; margin-bottom: 20px;">🎯 Nouvelle inscription LoopImmo</h2>
               <div style="background: white; padding: 20px; border-radius: 8px; border-left: 4px solid #48bb78;">
                 <p><strong>Email :</strong> ${email}</p>
+                <p><strong>Rôle :</strong> ${role || 'n/a'}</p>
                 <p><strong>Code de parrainage :</strong> <code style="background: #edf2f7; padding: 2px 6px; border-radius: 4px;">${referralCode}</code></p>
                 ${referredBy ? `<p><strong>Parrainé par :</strong> ${referredBy}</p>` : ''}
                 <p style="margin-top: 15px; font-size: 14px; color: #718096;">

--- a/src/pages/LaunchPageV2.tsx
+++ b/src/pages/LaunchPageV2.tsx
@@ -22,7 +22,7 @@ export const LaunchPageV2: React.FC = () => {
     return re.test(value);
   };
 
-  const handleEmailSubmit = async (e: React.FormEvent) => {
+  const handleEmailSubmit = (role: string) => async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!validateEmail(email)) {
@@ -34,7 +34,7 @@ export const LaunchPageV2: React.FC = () => {
       const res = await fetch('/api/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, referredBy: referralCode }),
+        body: JSON.stringify({ email, referredBy: referralCode, role }),
       });
 
       if (res.status === 409) {
@@ -430,7 +430,7 @@ export const LaunchPageV2: React.FC = () => {
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 mb-4">Prêt à vendre ?</h3>
 
-                <form onSubmit={handleEmailSubmit} className="space-y-4">
+                <form onSubmit={handleEmailSubmit('seller')} className="space-y-4">
                   <div>
                     <input
                       type="email"
@@ -502,7 +502,7 @@ export const LaunchPageV2: React.FC = () => {
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 mb-4">Devenir Looper</h3>
                 
-                <form onSubmit={handleEmailSubmit} className="space-y-4">
+                <form onSubmit={handleEmailSubmit('looper')} className="space-y-4">
                   <div>
                     <input
                       type="email"
@@ -662,7 +662,7 @@ export const LaunchPageV2: React.FC = () => {
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 mb-4">Prêt à acheter ?</h3>
                 
-                <form onSubmit={handleEmailSubmit} className="space-y-4">
+                <form onSubmit={handleEmailSubmit('buyer')} className="space-y-4">
                   <div>
                     <input
                       type="email"


### PR DESCRIPTION
## Summary
- allow LaunchPageV2 forms to specify the signup role
- store the role when inserting newsletter users in the API
- include role info in admin notification emails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a67eb93bc83308b5f0c26013a1a08