### PR TITLE
Read Turnstile site key from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ FRONTEND_URL=http://localhost:5174
 
 # Debug mode
 DEBUG=false
+
+# Cloudflare Turnstile Site Key
+VITE_TURNSTILE_SITE_KEY=your_site_key_here

--- a/src/components/shared/CloudflareTurnstile.tsx
+++ b/src/components/shared/CloudflareTurnstile.tsx
@@ -30,7 +30,7 @@ const CloudflareTurnstile = forwardRef<{ value: string | null }, TurnstileProps>
       script.onload = () => {
         if (widgetRef.current && window.turnstile) {
           const id = window.turnstile.render(widgetRef.current, {
-            sitekey: '0x4AAAAABiERNubU16D6CAE', // Votre clé du site
+            sitekey: import.meta.env.VITE_TURNSTILE_SITE_KEY,
             callback: (token: string) => {
               setValue(token)
               onSuccess?.(token)

--- a/src/pages/LaunchPageV2.tsx
+++ b/src/pages/LaunchPageV2.tsx
@@ -3,17 +3,6 @@ import { useSearchParams } from 'react-router-dom';
 import { ArrowRight, Users, TrendingDown, Shield, Home, Search, Euro, Clock, CheckCircle, Star, Heart, Zap, Award, UserCheck, FileCheck, Handshake, ArrowDown, Gift, Percent, UserPlus, Copy, Check, Info, X, Share2 } from 'lucide-react';
 import CloudflareTurnstile from '../components/shared/CloudflareTurnstile';
 
-// Déclaration TypeScript pour Turnstile
-declare global {
-  interface Window {
-    turnstile: {
-      render: (element: HTMLElement, options: any) => string;
-      remove: (widgetId: string) => void;
-      reset: (widgetId: string) => void;
-    };
-  }
-}
-
 export const LaunchPageV2: React.FC = () => {
   const [searchParams] = useSearchParams();
   const [email, setEmail] = useState('');

--- a/src/types/turnstile.d.ts
+++ b/src/types/turnstile.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    turnstile: {
+      render: (element: HTMLElement, options: any) => string
+      remove: (widgetId: string) => void
+      reset: (widgetId: string) => void
+    }
+  }
+}
+
+export {}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_LAUNCH_MODE: string
   readonly VITE_API_URL?: string
   readonly DATABASE_URL: string
+  readonly VITE_TURNSTILE_SITE_KEY?: string
   // Ajouter d'autres variables d'environnement ici si nécessaire
 }
 


### PR DESCRIPTION
## Summary
- read Turnstile site key from `import.meta.env`
- document `VITE_TURNSTILE_SITE_KEY` in `.env.example`
- define a shared `window.turnstile` type
- remove per-file Turnstile interface
- type environment variable in `vite-env.d.ts`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a91d0e188833096a3a616021c3a6f