### PR TITLE
Remove DB variable from frontend env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,6 @@ VITE_API_URL=http://localhost:3000
 # true = Landing page de lancement (avant le 1er septembre)
 # false = Page d'accueil traditionnelle (après le lancement)
 
-# PostgreSQL configuration
-DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
-
 # Base URL of the frontend used by the backend (for CORS)
 FRONTEND_URL=http://localhost:5174
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,7 +3,6 @@
 interface ImportMetaEnv {
   readonly VITE_LAUNCH_MODE: string
   readonly VITE_API_URL?: string
-  readonly DATABASE_URL: string
   // Ajouter d'autres variables d'environnement ici si nécessaire
 }
 


### PR DESCRIPTION
## Summary
- drop `DATABASE_URL` from frontend environment typings
- remove database URL example from root `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0dce2030833086ba6d81cb6551f4