### PR TITLE
Move FRONTEND_URL to server env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,5 @@ VITE_V2_MODE=true
 VITE_API_URL=http://localhost:3000
 # true = Landing page de lancement (avant le 1er septembre)
 # false = Page d'accueil traditionnelle (après le lancement)
-
-# Base URL of the frontend used by the backend (for CORS)
-FRONTEND_URL=http://localhost:5174
-
 # Debug mode
 DEBUG=false

--- a/server/.env.example
+++ b/server/.env.example
@@ -9,8 +9,8 @@ DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
 # EMAIL_FROM=noreply@example.com
 # EMAIL_TO=admin@example.com
 
-# Base URL of the frontend used to generate referral links
-# FRONTEND_URL=http://localhost:5174
+# Base URL of the frontend used to generate referral links and configure CORS
+FRONTEND_URL=http://localhost:5174
 
 # Optional: server port
 # PORT=3000

--- a/server/src/handlers/newsletter.ts
+++ b/server/src/handlers/newsletter.ts
@@ -7,9 +7,8 @@ import { randomUUID } from 'crypto';
 import { query } from '../db';
 import { log, error } from '../utils/logger';
 
-// Load server-specific environment variables for email credentials
-// The handler lives in `server/src/handlers`, so the root `.env`
-// resides two directories up from this file.
+// Load environment variables from the server root .env file.
+// The handler lives in `server/src/handlers`, so the .env file is two directories up.
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 export const subscribeNewsletter = async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- remove `FRONTEND_URL` from the frontend `.env.example`
- add `FRONTEND_URL` to `server/.env.example`
- clarify comment about `.env` location in newsletter handler

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c10bee7888330bff58dd82517f7bd