### PR TITLE
Fix CORS env handling

### DIFF
--- a/server/dist/index.js
+++ b/server/dist/index.js
@@ -42,7 +42,11 @@ const Sentry = __importStar(require("@sentry/node"));
 const db_1 = require("./db");
 const handlers_1 = require("./handlers");
 const logger_1 = require("./utils/logger");
-const allowedOrigin = process.env.FRONTEND_URL || '*';
+const allowedOrigin = process.env.FRONTEND_URL;
+if (!allowedOrigin) {
+    (0, logger_1.error)('FRONTEND_URL environment variable is not defined');
+    process.exit(1);
+}
 const app = (0, express_1.default)();
 const port = process.env.PORT || 3000;
 Sentry.init({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,12 @@ import { query, connectDb } from './db';
 import { subscribeNewsletter, register } from './handlers';
 import { log, error } from './utils/logger';
 
-const allowedOrigin = process.env.FRONTEND_URL || '*';
+const allowedOrigin = process.env.FRONTEND_URL;
+
+if (!allowedOrigin) {
+  error('FRONTEND_URL environment variable is not defined');
+  process.exit(1);
+}
 
 const app = express();
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- exit on missing `FRONTEND_URL` instead of defaulting to '*'

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cf40a6f608330bfebd43478204867