### PR TITLE
Update SSL config

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,7 @@
 # PostgreSQL connection URL
 DATABASE_URL=postgres://user:password@localhost:5432/loopimmo
+# Set PG_REJECT_UNAUTHORIZED=false in development to skip certificate verification
+# PG_REJECT_UNAUTHORIZED=false
 
 # Email configuration
 # SMTP_HOST=smtp.example.com

--- a/server/dist/db.js
+++ b/server/dist/db.js
@@ -18,11 +18,14 @@ else {
     (0, logger_1.log)(`Loaded environment variables from ${envPath}`);
 }
 // Configuration Pool optimisée pour OVH
+const isDev = process.env.NODE_ENV === 'development';
+const sslConfig = { rejectUnauthorized: true };
+if (isDev && process.env.PG_REJECT_UNAUTHORIZED === 'false') {
+    sslConfig.rejectUnauthorized = false;
+}
 const pool = new pg_1.Pool({
     connectionString: process.env.DATABASE_URL?.split('?')[0], // URL propre sans paramètres
-    ssl: {
-        rejectUnauthorized: false
-    },
+    ssl: sslConfig,
     // Paramètres valides pour PoolConfig
     max: 10, // Nombre max de connexions
     min: 2, // Nombre min de connexions maintenues

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -13,11 +13,15 @@ if (envResult.error) {
 }
 
 // Configuration Pool optimisée pour OVH
+const isDev = process.env.NODE_ENV === 'development';
+const sslConfig = { rejectUnauthorized: true };
+if (isDev && process.env.PG_REJECT_UNAUTHORIZED === 'false') {
+  sslConfig.rejectUnauthorized = false;
+}
+
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL?.split('?')[0], // URL propre sans paramètres
-  ssl: {
-    rejectUnauthorized: false
-  },
+  ssl: sslConfig,
   // Paramètres valides pour PoolConfig
   max: 10, // Nombre max de connexions
   min: 2,  // Nombre min de connexions maintenues


### PR DESCRIPTION
## Summary
- default to verifying SSL connections in the database pool
- add PG_REJECT_UNAUTHORIZED to `.env.example` for local dev overrides

## Testing
- `npm --prefix server run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685cf41b5f6483309d894bbf98e2c95a