### PR TITLE
Disable debug-sentry route in production

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -49,9 +49,11 @@ app.get('/', (_req: Request, res: Response) => {
 });
 
 // Test route to verify Sentry configuration
-app.get('/debug-sentry', (_req: Request, _res: Response) => {
-  throw new Error('Test Sentry error');
-});
+if (process.env.NODE_ENV !== 'production') {
+  app.get('/debug-sentry', (_req: Request, _res: Response) => {
+    throw new Error('Test Sentry error');
+  });
+}
 
 // Error handler must come after routes
 app.use(Sentry.Handlers.errorHandler());


### PR DESCRIPTION
## Summary
- hide the `/debug-sentry` endpoint unless `NODE_ENV` is not `production`

## Testing
- `npm run lint` *(fails: could not find `package.json`)*
- `npm run build` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685cf42800b08330b8ce496cdd64297a