### PR TITLE
Update SSL setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ are running Node.js 18 or later.
 
 The API listens on port `3000` by default and currently exposes `/api/users` and `/api/properties` routes.
 
-If your `DATABASE_URL` contains `sslmode=require` for a cloud database using a
-self-signed certificate, the server automatically disables certificate
-verification so that `pg` can connect without errors.
+If your `DATABASE_URL` uses `sslmode=require` with a self-signed certificate,
+set `PG_REJECT_UNAUTHORIZED=false` in `server/.env` during development to skip
+certificate verification so `pg` can connect without errors.
 
 ### Email configuration
 


### PR DESCRIPTION
## Summary
- document `PG_REJECT_UNAUTHORIZED` in the README
- remove old note about automatic detection of `sslmode=require`

## Testing
- `npm run lint` *(fails: cannot read package.json)*
- `npm run build` *(fails: cannot read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cf9dc1ba48330947bcd76bf3754a7