### PR TITLE
Fix DB connection for self-signed SSL

### DIFF
--- a/server/dist/db.js
+++ b/server/dist/db.js
@@ -19,10 +19,14 @@ else {
 }
 // Configuration Pool optimisée pour OVH
 const isDev = process.env.NODE_ENV === 'development';
-const sslConfig = { rejectUnauthorized: true };
-if (process.env.PG_REJECT_UNAUTHORIZED !== undefined) {
-    sslConfig.rejectUnauthorized = process.env.PG_REJECT_UNAUTHORIZED !== 'false';
-}
+// Allow disabling certificate validation when using self-signed certificates.
+// Default to `false` so deployments like Railway can connect without needing
+// an extra environment variable.
+const sslConfig = {
+    rejectUnauthorized: process.env.PG_REJECT_UNAUTHORIZED !== undefined
+        ? process.env.PG_REJECT_UNAUTHORIZED !== 'false'
+        : false,
+};
 const pool = new pg_1.Pool({
     connectionString: process.env.DATABASE_URL?.split('?')[0], // URL propre sans paramètres
     ssl: sslConfig,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -14,10 +14,15 @@ if (envResult.error) {
 
 // Configuration Pool optimisée pour OVH
 const isDev = process.env.NODE_ENV === 'development';
-const sslConfig = { rejectUnauthorized: true };
-if (process.env.PG_REJECT_UNAUTHORIZED !== undefined) {
-  sslConfig.rejectUnauthorized = process.env.PG_REJECT_UNAUTHORIZED !== 'false';
-}
+// Allow disabling certificate validation when using self-signed certificates.
+// Default to `false` so deployments like Railway can connect without needing
+// an extra environment variable.
+const sslConfig = {
+  rejectUnauthorized:
+    process.env.PG_REJECT_UNAUTHORIZED !== undefined
+      ? process.env.PG_REJECT_UNAUTHORIZED !== 'false'
+      : false,
+};
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL?.split('?')[0], // URL propre sans paramètres


### PR DESCRIPTION
## Summary
- relax SSL validation in the server DB pool so platforms like Railway work without extra env vars

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cffd9c2d083309e05f09058d00798