### PR TITLE
Fix truncated text in slider

### DIFF
--- a/frontend/src/utils/CommissionSlider.tsx
+++ b/frontend/src/utils/CommissionSlider.tsx
@@ -52,7 +52,7 @@ export function CommissionSlider() {
 
         {/* Bloc économie */}
         <div className="space-y-1 min-w-0">
-          <span className="block text-gray-500 text-xs truncate">
+          <span className="block text-gray-500 text-xs">
             LoopImmo fait économiser jusqu'à
           </span>
           <span className="text-green-600 text-lg md:text-2xl font-bold whitespace-nowrap truncate">


### PR DESCRIPTION
## Summary
- avoid truncation of the economy message on LaunchPageV2

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package 'globals')*
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e972263b08330bfd9ae71a47e4b9d