### PR TITLE
Add proxy server to frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc -p tsconfig.server.json && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start": "npx serve -s dist -p $PORT"
+    "start": "node dist/server.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -24,7 +24,9 @@
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
     "@types/leaflet": "^1.9.8",
-    "serve": "^14.2.1"
+    "serve": "^14.2.1",
+    "express": "^4.18.2",
+    "http-proxy-middleware": "^2.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -40,6 +42,9 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "@types/express": "^4.17.21",
+    "@types/http-proxy-middleware": "^2.0.5",
+    "ts-node": "^10.9.2"
   }
 }

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -1,0 +1,26 @@
+import express from 'express'
+import { createProxyMiddleware } from 'http-proxy-middleware'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const app = express()
+
+const PORT = process.env.PORT || 3000
+const BACKEND_URL = process.env.BACKEND_URL || 'http://backend.railway.internal:3001'
+
+app.use('/api', createProxyMiddleware({
+  target: BACKEND_URL,
+  changeOrigin: true,
+  pathRewrite: { '^/api': '' },
+}))
+
+app.use(express.static(path.join(__dirname, 'dist')))
+
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'dist', 'index.html'))
+})
+
+app.listen(PORT, () => {
+  console.log(`Frontend server running on port ${PORT}`)
+})

--- a/frontend/tsconfig.server.json
+++ b/frontend/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["server.ts"]
+}


### PR DESCRIPTION
## Summary
- add Express proxy server for frontend
- update scripts and deps to build and run server
- add tsconfig for server build

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870cba4e494833083b69d83fc5747b6