### PR TITLE
Fix missing proxy middleware type package version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2",
     "@types/express": "^4.17.21",
-    "@types/http-proxy-middleware": "^2.0.5",
+    "@types/http-proxy-middleware": "^2.0.6",
     "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- bump `@types/http-proxy-middleware` to a valid version

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6870d32d825083308c6a67b0b79ae9c7