### PR TITLE
Fix invalid http-proxy-middleware type package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,6 @@
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2",
     "@types/express": "^4.17.21",
-    "@types/http-proxy-middleware": "^2.0.6",
     "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- remove `@types/http-proxy-middleware` dev dependency

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870d4b9aa7c8330955f0354493c072c