### PR TITLE
Fix API URL usage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { LaunchPageV2 } from './pages/LaunchPageV2';
 import { LoginPage } from './pages/auth/LoginPage';
 import { RegisterPage } from './pages/auth/RegisterPage';
 import { AcheterPage } from './pages/AcheterPage';
+import { apiUrl } from './utils/api';
 import { VendrePage } from './pages/VendrePage';
 import { LooperPage } from './pages/LooperPage';
 import { PropertyDetailPage } from './pages/PropertyDetailPage';
@@ -27,7 +28,7 @@ function App() {
 
 useEffect(() => {
   // Preload backend connection without exposing environment details in the console
-  fetch('/api/users', { method: 'GET' }).catch(() => {
+  fetch(apiUrl('/api/users'), { method: 'GET' }).catch(() => {
     // Silently ignore connection errors
   });
 }, []);

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { User, UserRole } from '../types';
 import { getUsers } from '../services/dataService';
+import { apiUrl } from '../utils/api';
 
 const useMocks = import.meta.env.VITE_USE_MOCKS !== 'false';
 
@@ -74,7 +75,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
    const register = async (data: RegisterData) => {
     if (!useMocks) {
-      const res = await fetch('/api/register', {
+      const res = await fetch(apiUrl('/api/register'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/src/pages/LaunchPage.tsx
+++ b/frontend/src/pages/LaunchPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { apiUrl } from "../utils/api";
 import {
   Calendar,
   Users,
@@ -55,7 +56,7 @@ export const LaunchPage: React.FC = () => {
     }
     setIsLoading(true);
     try {
-      const res = await fetch("/api/subscribe", {
+      const res = await fetch(apiUrl("/api/subscribe"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, role, referredBy }),

--- a/frontend/src/pages/LaunchPageV2.tsx
+++ b/frontend/src/pages/LaunchPageV2.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
+import { apiUrl } from "../utils/api";
 import {
   ArrowRight,
   Users,
@@ -68,7 +69,7 @@ export const LaunchPageV2: React.FC = () => {
 
     setIsLoading(true);
     try {
-      const res = await fetch('/api/subscribe', {
+      const res = await fetch(apiUrl('/api/subscribe'), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, referredBy: referralCode, role, token }),

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,5 @@
+export function apiUrl(path: string): string {
+  const base = import.meta.env.VITE_API_URL;
+  return base ? `${base}${path}` : path;
+}
+


### PR DESCRIPTION
## Summary
- add helper to build API URLs from `VITE_API_URL`
- use `apiUrl()` when calling backend in LaunchPageV2
- use `apiUrl()` when calling backend in LaunchPage
- use `apiUrl()` when registering users
- use `apiUrl()` during backend preload

## Testing
- `npm run lint` *(fails: ENOENT package.json)*
- `npm run build` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870ddcc0538833081d2b614eaca2267