### PR TITLE
Enable private networking proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ After building, start the proxy server with:
 npm start
 ```
 
-This `server.ts` script serves the static files from `dist` and forwards all
+The `server.js` script now serves the static files from `dist` and proxies
 `/api` requests to the backend specified by the `BACKEND_URL` environment
-variable.
+variable. It listens on IPv6 to support Railway's private networking.
 
 Build for production:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.server.json && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start": "node dist/server.js"
+    "start": "node server.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+const path = require('path');
+const app = express();
+
+app.use('/api', createProxyMiddleware({
+  target: process.env.BACKEND_URL,
+  changeOrigin: true,
+  pathRewrite: { '^/api': '' }
+}));
+
+app.use(express.static(path.join(__dirname, 'dist')));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, '::');

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -12,6 +12,7 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://backend.railway.internal:
 app.use('/api', createProxyMiddleware({
   target: BACKEND_URL,
   changeOrigin: true,
+  pathRewrite: { '^/api': '' },
 }))
 
 app.use(express.static(path.join(__dirname, 'dist')))
@@ -20,6 +21,6 @@ app.get('*', (_req, res) => {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'))
 })
 
-app.listen(PORT, () => {
+app.listen(PORT, '::', () => {
   console.log(`Frontend server running on port ${PORT}`)
 })

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -68,7 +68,7 @@ app.use(Sentry.Handlers.errorHandler());
 
 connectDb()
   .then(() => {
-    app.listen(port, () => {
+    app.listen(port, '::', () => {
       log(`Server listening on port ${port}`);
     });
   })


### PR DESCRIPTION
## Summary
- serve backend on IPv6 for Railway
- proxy API calls through a new frontend server
- update frontend start script
- document the new server.js usage

## Testing
- `npm run lint` *(fails: missing package.json)*
- `npm run build` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870e3a550808330bf1de42f6d073f61