### PR TITLE
Fix server port type

### DIFF
--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const app = express()
 
-const PORT = process.env.PORT || 3000
+const PORT = parseInt(process.env.PORT || '3000', 10)
 const BACKEND_URL = process.env.BACKEND_URL || 'http://backend.railway.internal:3001'
 
 app.use('/api', createProxyMiddleware({


### PR DESCRIPTION
## Summary
- fix port parsing for Express server to satisfy TypeScript

## Testing
- `npm --prefix frontend run lint` *(fails: cannot find package 'globals')*
- `npm --prefix frontend run build` *(fails: cannot find module 'express' and other types)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6870ef3294cc8330864b3f9dc3108cf0