### PR TITLE
feat: add PWA scaffold

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,8 @@
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/logoS.svg" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#ffffff" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description"
     content="LoopImmo - La vente immobilière réinventée. Économisez jusqu'à 90% sur vos frais d'agence avec notre système de forfaits transparents." />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "@types/leaflet": "^1.9.8",
     "serve": "^14.2.1",
     "express": "^4.18.2",
-    "http-proxy-middleware": "^2.0.6"
+    "http-proxy-middleware": "^2.0.6",
+    "workbox-window": "^7.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -44,6 +45,7 @@
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2",
     "@types/express": "^4.17.21",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "vite-plugin-pwa": "^0.17.4"
   }
 }

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "LoopImmo",
+  "short_name": "LoopImmo",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "description": "LoopImmo - La vente immobilière communautaire",
+  "icons": [
+    {
+      "src": "/logoS.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/logoS.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import './styles/animations.css';
+import { Workbox } from 'workbox-window';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -12,3 +13,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </BrowserRouter>
   </React.StrictMode>
 );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    const wb = new Workbox('/sw.js');
+    wb.register();
+  });
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
   return {
-    plugins: [react()],
+    plugins: [
+      react(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        manifest: false,
+        includeAssets: ['logo.svg', 'logoS.svg']
+      })
+    ],
     server: {
       proxy: {
         '/api': env.VITE_API_URL || 'http://localhost:3000',


### PR DESCRIPTION
## Summary
- configure Vite with PWA plugin
- add web manifest and service worker registration
- include theme color and manifest link for PWA

## Testing
- `npm --prefix frontend run lint` *(fails: Config at index 1 ... not supported)*
- `npm --prefix frontend run build` *(fails: Cannot find package 'vite-plugin-pwa')*

------
https://chatgpt.com/codex/tasks/task_e_689b9b1e86ec833095b22e3d752e47e3