### PR TITLE
feat: streamline PWA registration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,8 +26,7 @@
     "@types/leaflet": "^1.9.8",
     "serve": "^14.2.1",
     "express": "^4.18.2",
-    "http-proxy-middleware": "^2.0.6",
-    "workbox-window": "^7.0.0"
+    "http-proxy-middleware": "^2.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,7 +1,9 @@
 {
+  "id": "/",
   "name": "LoopImmo",
   "short_name": "LoopImmo",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import './styles/animations.css';
-import { Workbox } from 'workbox-window';
+import { registerSW } from 'virtual:pwa-register';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -14,9 +14,4 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   </React.StrictMode>
 );
 
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    const wb = new Workbox('/sw.js');
-    wb.register();
-  });
-}
+registerSW();


### PR DESCRIPTION
## Summary
- add explicit id and scope to web manifest
- switch to vite-plugin-pwa's registerSW helper
- remove unused workbox-window dependency

## Testing
- `npm run lint --prefix frontend` *(fails: Config at index 1 has an 'extends' array with string 'eslint:recommended')*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689ba2513df883309dc5f471fcdaacac