### PR TITLE
feat: use new PWA logo on launch page

### DIFF
--- a/frontend/src/pages/LaunchPageV2.tsx
+++ b/frontend/src/pages/LaunchPageV2.tsx
@@ -262,7 +262,7 @@ export const LaunchPageV2: React.FC = () => {
           {/* Logo */}
           <div className="mb-8">
             <img
-              src="/logo.svg"
+              src="/logoS.svg"
               alt="LoopImmo"
               className="h-24 md:h-32 lg:h-40 mx-auto"
             />
@@ -449,7 +449,7 @@ export const LaunchPageV2: React.FC = () => {
           {/* Logo */}
           <div className="mb-8">
             <img
-              src="/logo.svg"
+              src="/logoS.svg"
               alt="LoopImmo"
               className="h-16 md:h-20 lg:h-24 mx-auto"
             />
@@ -1212,7 +1212,7 @@ export const LaunchPageV2: React.FC = () => {
           {/* Logo */}
           <div className="mb-8">
             <img
-              src="/logo.svg"
+              src="/logoS.svg"
               alt="LoopImmo"
               className="h-12 md:h-16 mx-auto filter brightness-0 invert"
             />


### PR DESCRIPTION
## Summary
- switch LaunchPageV2 to new PWA-friendly logo

## Testing
- `npm --prefix frontend run lint` *(fails: Config at index 1 has an 'extends' array with string "eslint:recommended")*
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba3f06cc88330833d481d61dce7dd